### PR TITLE
添加“一直生效 hosts” 功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ projectFilesBackup
 
 *.hosts
 
+src/hosts
 src/configs.json
 
 *.swh

--- a/src/SwitchHosts.py
+++ b/src/SwitchHosts.py
@@ -12,7 +12,7 @@ from libs.MainFrame import MainFrame
 
 class SwitchHostsApp(object):
 
-    VERSION = "0.2.1.1780"
+    VERSION = "0.2.1.1781"
 
     def __init__(self):
 

--- a/src/libs/Hosts.py
+++ b/src/libs/Hosts.py
@@ -4,6 +4,8 @@
 # blog: http://oldj.net
 # email: oldj.wu@gmail.com
 #
+# update by allenm 2012-11-15 添加一直生效 hosts 功能
+#
 
 import os
 import simplejson as json
@@ -18,10 +20,11 @@ class Hosts(object):
     flag = "#@SwitchHosts!"
     old_flag = "#@SwitchHost!"
 
-    def __init__(self, path, is_origin=False, title=None, url=None):
+    def __init__(self, path, is_origin=False, is_forever=False, title=None, url=None):
 
         self.path = path
         self.is_origin = is_origin
+        self.is_forever = is_forever
         self.url = url
         self.is_online = True if url else False
         self.is_loading = False
@@ -153,7 +156,7 @@ class Hosts(object):
         if type(cfg) != dict:
             return
 
-        if self.is_origin:
+        if self.is_origin or self.is_forever:
             pass
         elif cfg.get("title"):
             if not self.title or not self.is_online:
@@ -197,7 +200,7 @@ class Hosts(object):
         return os.linesep.join(cnt_for_save).encode("utf-8")
 
 
-    def save(self, path=None):
+    def save(self, path=None, extraContent=""):
 
         if self.last_save_time:
             time_delta = time.time() - self.last_save_time
@@ -209,10 +212,14 @@ class Hosts(object):
         path = path or self.path
         path = path.encode(co.getLocalEncoding())
 
-        open(path, "w").write(self.full_content)
+        open(path, "w").write( self.full_content + self.encodeText(extraContent) )
         self.last_save_time = time.time()
 
         return True
+
+    def encodeText(self, text):
+
+        return os.linesep.join( text.split("\n") ).encode("utf-8")
 
 
     def remove(self):

--- a/src/libs/lang.py
+++ b/src/libs/lang.py
@@ -10,6 +10,7 @@ lang = {
     "origin_hosts": u"当前系统 hosts",
     "online_hosts": u"在线方案",
     "local_hosts": u"本地方案",
+    "forever_hosts": u"一直生效 hosts",
 }
 
 def trans(key):

--- a/src/libs/ui.py
+++ b/src/libs/ui.py
@@ -68,6 +68,7 @@ class Frame(wx.Frame):
         self.m_tree.SetBackgroundColour(wx.Colour(218, 223, 230))
         self.m_tree_root = self.m_tree.AddRoot(u"hosts")
         self.m_tree_origin = self.m_tree.AppendItem(self.m_tree_root, lang.trans("origin_hosts"))
+        self.m_tree_forever = self.m_tree.AppendItem( self.m_tree_root , lang.trans("forever_hosts"))
         self.m_tree_local = self.m_tree.AppendItem(self.m_tree_root, lang.trans("local_hosts"))
         self.m_tree_online = self.m_tree.AppendItem(self.m_tree_root, lang.trans("online_hosts"))
         self.m_tree.SetItemTextColour(self.m_tree_root, "#999999")


### PR DESCRIPTION
在使用过程中，我发现，有些 hosts 经常是无论在什么情况下都需要绑定的，例如  localhost ，或者是对国外的某些网站的绑定。

所以我尝试加入了一项“一直生效 hosts” ，无论选择哪个方案，都会自动把这一项里的 hosts 给追加到后面。
