### PR TITLE
设置False 参数不会把 stdout/stderr 输出到窗口, 便于在命令行启动时调试;

### DIFF
--- a/src/SwitchHosts.py
+++ b/src/SwitchHosts.py
@@ -37,7 +37,7 @@ class SwitchHostsApp(object):
 
         while True:
 
-            app = wx.App()
+            app = wx.App(False)
 
             instance_name = "%s-%s" % (app.GetAppName(), wx.GetUserId())
             instance_checker = wx.SingleInstanceChecker(instance_name, self.working_path)


### PR DESCRIPTION
今天fork了一个; 发现在mac 用命令行启动后闪退; 无法看到错误报告;
看wx文档后发现:

```
app = wx.App(False)  # Create a new app, don't redirect stdout/stderr to a window.
```

修改之后启动, 之后看到有错误输出:

```
File "/Users/liangwei/SwitchHosts/SwitchHosts/src/libs/ui.py", line 224, in makeTextCtrl
     txt_ctrl.SetMaxLength(0)
AttributeError: 'HostsCtrl' object has no attribute 'SetMaxLength'
```

验证:
不设置参数, 在 wx.App() 后使用print 'aaaa' , 可看到GUI窗口有'aaaa' 字符;
