### PR TITLE
Hi，我增加了一个自动记忆sudo密码的功能。

### DIFF
--- a/src/libs/MainFrame.py
+++ b/src/libs/MainFrame.py
@@ -23,6 +23,7 @@ from TaskbarIcon import TaskBarIcon
 from BackThreads import BackThreads
 import common_operations as co
 import lang
+import base64
 
 sys_type = co.getSystemType()
 
@@ -312,7 +313,7 @@ class MainFrame(ui.Frame):
                 return False
 
             self.sudo_password = pswd
-            self.writeFile(self.passwd_path, pswd)
+            self.writeFile(self.passwd_path, base64.encodestring(pswd))
 
         #尝试通过sudo密码保存
         try:
@@ -1261,7 +1262,7 @@ class MainFrame(ui.Frame):
     def getPassword(self):
         try:
             f = open(self.passwd_path) 
-            passwd = f.read().strip()
+            passwd = base64.decodestring(f.read())
             f.close()
             return passwd
         except Exception:


### PR DESCRIPTION
由于每次打开SwitchHosts,都会要求输入Sudo密码，挺烦人的。
所以我加了一个小功能，若第一次打开SwitchHosts，输入Sudo密码后会把Sudo密码保存在working_path/passwd中。
以后每次打开SwitchHosts，初始化MainFrame的时候都会读取working_path/passwd，就不用再输入Sudo密码了~
