### PR TITLE
在LINUX下的一些问题FIX

### DIFF
--- a/src/libs/MainFrame.py
+++ b/src/libs/MainFrame.py
@@ -30,6 +30,7 @@ if sys_type == "linux":
     # Linux
     try:
         import pynotify
+	pynotify.init("SwitchHosts!")
     except ImportError:
         pynotify = None
 elif sys_type == "mac":
@@ -386,7 +387,7 @@ class MainFrame(ui.Frame):
                 os.popen(cmd)
 
             elif self.sys_type == "linux":
-                cmd = "/etc/init.d/nscd restart"
+                cmd = "service nscd restart"
                 os.popen(cmd)
 
         except Exception:
@@ -970,7 +971,7 @@ class MainFrame(ui.Frame):
         if self.is_switching_text:
             return
 
-        self.current_showing_hosts.content = self.m_textCtrl_content.GetValue()
+        self.current_showing_hosts.content = self.m_textCtrl_content.GetText().strip()
         self.saveHosts(self.current_showing_hosts)
 
     def OnChkUpdate(self, event):

--- a/src/libs/TaskbarIcon.py
+++ b/src/libs/TaskbarIcon.py
@@ -92,22 +92,20 @@ class TaskBarIcon(wx.TaskBarIcon):
 
         item_id = wx.NewId()
         title = hosts.title if not hosts.is_origin else lang.trans("origin_hosts")
-        mitem = wx.MenuItem(menu, item_id, title, kind=wx.ITEM_CHECK)
+        mitem = wx.MenuItem(menu, item_id, title)
         mitem.SetBitmap(co.GetMondrianBitmap(hosts.icon_idx))
-        menu.AppendItem(mitem)
 
         is_using = self.main_frame.current_using_hosts == hosts
-        menu.Check(item_id, is_using)
         if is_using:
             mitem.SetFont(self.font_bold)
 #        self.hosts[item_id] = title
         hosts.taskbar_id = item_id
-
+	menu.AppendItem(mitem)
         self.Bind(wx.EVT_MENU, self.switchHosts, id=item_id)
 
 
-    def switchHosts(self, event):
 
+    def switchHosts(self, event):
         item_id = event.GetId()
         for hosts in self.main_frame.all_hostses:
             if hosts.taskbar_id == item_id:

--- a/src/libs/ui.py
+++ b/src/libs/ui.py
@@ -221,7 +221,7 @@ class Frame(wx.Frame):
             pos=wx.DefaultPosition,
             size=wx.DefaultSize,
             style=wx.TE_MULTILINE|wx.TE_RICH2|wx.TE_PROCESS_TAB|wx.HSCROLL|wx.NO_BORDER)
-        txt_ctrl.SetMaxLength(0)
+        txt_ctrl.AutoCompSetMaxWidth(0)
 
         container.Add(txt_ctrl, 1, wx.ALL | wx.EXPAND, 0)
 


### PR DESCRIPTION
环境
LINUX KERNEL：3.1.5.6
LIBNOTIFY：0.76
python：2.7.5
wxPython：2.8.0

1.修正libnotify 0.76以后需要初始化后才能使用
2.修正在fedora 20下（未验证其他linux版本）托盘菜单崩溃问题（menu.Check()引起Segment Fault）
3.因为对wxPYTHON并不熟悉，暂时没有时间去处理在LINUX无法创建Checkable菜单以及显示图标，采用了简单的去除这些功能。修正事件绑定无效等问题
4./etc/init.d/nscd过时，改为采用service方式刷新dns缓存。另外这部分没有添加sudo权限认证
