### PR TITLE
Restore main window when command "activate" being called

### DIFF
--- a/app/SH3/MacGap/Classes/Commands/App.m
+++ b/app/SH3/MacGap/Classes/Commands/App.m
@@ -59,7 +59,8 @@
 }
 
 - (void) activate {
-    [NSApp activateIgnoringOtherApps:YES];
+    [[NSRunningApplication currentApplication] activateWithOptions:(NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps)];
+    [[NSApplication sharedApplication].windows.firstObject makeKeyAndOrderFront:nil];
 }
 
 - (void) hide {


### PR DESCRIPTION
Fix #98
在 最小化/关闭 主窗体后，调用 `activate` 无法激活主界面。