### PR TITLE
禁用全屏模式

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -29,7 +29,8 @@ function createWindow() {
     // Create the browser window.
     mainWindow = new BrowserWindow({
         width: 800, height: 500,
-        minWidth: 400, minHeight: 250
+        minWidth: 400, minHeight: 250,
+        fullscreenable: false
     });
     contents = mainWindow.webContents;
     app.mainWindow = mainWindow;


### PR DESCRIPTION
在 macOS 下，选择全屏后除非退出应用，否则无法切回原始窗口模式。而全屏并没有什么实际的用处。
所以禁用全屏模式提升用户体验。