### PR TITLE
show 'Current effective config' after tray-icon

### DIFF
--- a/app/lang/cn.js
+++ b/app/lang/cn.js
@@ -24,6 +24,7 @@ exports.content = {
   , confirm_del: '确定要删除此 hosts 方案吗？'
   , confirm_import: '确定要导入吗？原方案列表将被覆盖，此操作不可撤销。'
   // , current_version: '当前版本：'
+  , current_active_hosts: '当前生效配置'
   , day: '天'
   , days: '天'
   , del_hosts: '删除当前 hosts 方案'

--- a/app/lang/en.js
+++ b/app/lang/en.js
@@ -24,6 +24,7 @@ exports.content = {
   , confirm_del: 'Are you sure you want to delete this hosts?'
   , confirm_import: 'You sure you want to import it? The original rules will be overwriten, this operation can not be undone.'
   // , current_version: 'Current version: '
+  , current_active_hosts: 'Current effective config'
   , day: 'day'
   , days: 'days'
   , del_hosts: 'Delete current hosts'

--- a/app/menu/tray.js
+++ b/app/menu/tray.js
@@ -107,20 +107,50 @@ function makeMenu (app, list, contents, sys_lang) {
   return menu
 }
 
+function makeTitle(list = []) {
+  const currItems = (list || []).filter(item => item.on) || []
+
+  const appendTitleEvt = function(lis = [], opr = ',') {
+    let _str = ''
+    if(lis.length) {
+      const appendTitle = (prev, curr) => {
+        return {
+          title: `${prev.title}${prev.title ? `${opr}` : ''}${curr.title}`
+        }
+      }
+      _str = currItems.reduce(appendTitle, { title: '' }).title || ''
+    }
+    return _str;
+  };
+
+  const _ori = appendTitleEvt(list)
+
+  return {
+    ori: _ori,
+    show: _ori.length > 20 ? `${_ori.substr(0, 20)}...` : _ori,
+    tips: `${appendTitleEvt(list, '\n')}`
+  }
+}
+
+
 function makeTray (app, contents, sys_lang = 'en') {
+  const lang = m_lang.getLang(sys_lang)
+
   let icon = 'logo.png'
   if (process.platform === 'darwin') {
     icon = 'ilogoTemplate.png'
   }
 
   tray = new Tray(path.join(__dirname, '..', 'assets', icon))
-  tray.setToolTip('SwitchHosts!')
 
   svr.on('update_tray', () => {
     getUserHosts()
       .then(list => {
         let contextMenu = Menu.buildFromTemplate(makeMenu(app, list, contents, sys_lang))
         tray.setContextMenu(contextMenu)
+        const { ori = '', show = '', tips = '' } = makeTitle(list)
++       tray.setTitle(show)
++       tray.setToolTip(ori ? `\n${lang.current_active_hosts}: \n\n${tips}\n` : 'SwitchHosts!')
       })
   })
 


### PR DESCRIPTION
As mentioned in the title:

![2019-06-28 18.07.51.gif](https://i.loli.net/2019/06/28/5d15e7a32defa24339.gif)