### PR TITLE
add portable mode support

### DIFF
--- a/app/server/paths.js
+++ b/app/server/paths.js
@@ -5,6 +5,7 @@
 
 'use strict'
 
+const fs = require('fs')
 const path = require('path')
 const io = require('./io')
 const platform = process.platform
@@ -12,8 +13,32 @@ const platform = process.platform
 // Windows 系统有可能不安装在 C 盘
 const sys_hosts_path = platform === 'win32' ? `${process.env.windir || 'C:\\WINDOWS'}\\system32\\drivers\\etc\\hosts` : '/etc/hosts'
 
+const appRoot = path.dirname(__dirname)
+
+function getApplicationPath() {
+  if (process.platform === 'darwin') {
+    return path.dirname(path.dirname(path.dirname(appRoot)))
+  }
+
+  return path.dirname(path.dirname(appRoot))
+}
+
+function getPortableDataPath() {
+  if (process.env['SWITCHHOSTS_PORTABLE']) {
+    return process.env['SWITCHHOSTS_PORTABLE'];
+  }
+
+  if (process.platform === 'win32' || process.platform === 'linux') {
+    return path.join(getApplicationPath(), 'data');
+  }
+
+  return path.join(path.dirname(getApplicationPath()), '.SwitchHosts-Data');
+}
+const portableDataPath = getPortableDataPath()
+const isPortable = fs.existsSync(portableDataPath)
+
 const home_path = io.getUserHome()
-const work_path = path.join(home_path, '.SwitchHosts')
+const work_path = isPortable ? portableDataPath : path.join(home_path, '.SwitchHosts')
 const data_path = path.join(work_path, 'data.json')
 const preference_path = path.join(work_path, 'preferences.json')
 


### PR DESCRIPTION
 **添加便携模式支持**
在程序目录创建data文件夹，配置文件会从data获取，也可通过 **SWITCHHOSTS_PORTABLE** 环境变量自定义路径，环境变量优先级高于data目录，mac下有点特殊为程序同级目录下的.SwitchHosts-Data
 可为 #327 这类问题提供一个解决方案

代码参考了 [vscode](https://github.com/microsoft/vscode/blob/0163f671e1d43fc68d1ccd9dc81dc05014cf8056/src/bootstrap.js#L250-L307) 
vscode portable说明https://code.visualstudio.com/docs/editor/portable