### PR TITLE
fix the problem about 'SnoreToast' is added to Start Menu

### DIFF
--- a/app/server/actions/notify.js
+++ b/app/server/actions/notify.js
@@ -14,7 +14,8 @@ module.exports = (svr, title, message) => {
       notifier.notify({
         title,
         message,
-        icon: path.join(__dirname, '..', '..', 'assets', 'logo@512w.png')
+        icon: path.join(__dirname, '..', '..', 'assets', 'logo@512w.png'),
+        appName: 'SwitchHosts!'
       }, (e) => {
         if (e) {
           console.log(e)


### PR DESCRIPTION
After setting 'appName' option , 'SnoreToast'  is not added to Start Menu.