### PR TITLE
run application with admin privileges in windows

### DIFF
--- a/scripts/make.js
+++ b/scripts/make.js
@@ -66,7 +66,8 @@ const makeApp = async () => {
         artifactName: '${productName}_macOS_${version}(${buildVersion}).${ext}'
       },
       win: {
-        icon: 'assets/app.ico'
+        icon: 'assets/app.ico',
+        requestedExecutionLevel: 'requireAdministrator'
       },
       nsis: {
         //installerIcon: 'assets/installer-icon.ico',


### PR DESCRIPTION
Set 'requestedExecutionLevel = requireAdministrator'  in order to get access to admin privileges in windows.