### PR TITLE
Optimize the appearance in dark mode

### DIFF
--- a/src/renderer/components/Editor/HostsEditor.less
+++ b/src/renderer/components/Editor/HostsEditor.less
@@ -66,6 +66,10 @@
       cursor: pointer;
       font-size: 12px;
     }
+
+    .CodeMirror-scrollbar-filler{
+      background: var(--swh-scrollbar-filler);
+    }
   }
 }
 

--- a/src/renderer/styles/common.less
+++ b/src/renderer/styles/common.less
@@ -7,6 +7,7 @@ html, body {
   line-height: 1.5em;
   box-sizing: border-box;
   color: var(--swh-font-color);
+  color-scheme: var(--swh-color-scheme);
 }
 
 button, a, input {

--- a/src/renderer/styles/themes/dark.less
+++ b/src/renderer/styles/themes/dark.less
@@ -59,7 +59,7 @@
   --swh-editor-error: #ff5990;
   --swh-editor-comment: #91af91;
   --swh-editor-hl-bg: #ff0;
-  --swh-editor-gutter-bg: #282C34;
+  --swh-editor-gutter-bg: #282c34;
 
   // tray
   --swh-tray-header-bg: #272b34;
@@ -69,8 +69,12 @@
   --swh-scrollbar-track: rgba(204, 204, 204, 0.25);
   --swh-scrollbar-corner: #fff;
   --swh-scrollbar-thumb: #ccc;
+  --swh-scrollbar-filler: #2b2b2b;
 
   // other componets
   --tree-drag-select-bg-color: var(--swh-tree-selected-bg);
   --tree-drag-indicator-color: var(--swh-primary-color);
+
+  //color-scheme
+  --swh-color-scheme: dark;
 }

--- a/src/renderer/styles/themes/light.less
+++ b/src/renderer/styles/themes/light.less
@@ -69,8 +69,12 @@
   --swh-scrollbar-track: rgba(204, 204, 204, 0.25);
   --swh-scrollbar-corner: #fff;
   --swh-scrollbar-thumb: #ccc;
+  --swh-scrollbar-filler: #fafafa;
 
   // other componets
   --tree-drag-select-bg-color: var(--swh-tree-selected-bg);
   --tree-drag-indicator-color: var(--swh-primary-color);
+
+  //color-scheme
+  --swh-color-scheme: light;
 }


### PR DESCRIPTION
Use  `color-scheme` optimize scrollbar appearance in dark mode

Before:

![Screen Shot 2021-12-22 at 20 04 57](https://user-images.githubusercontent.com/25996236/147171483-22a3d7fe-b498-46bb-ad65-c681282d03dd.png)

After:

![Screen Shot 2021-12-22 at 20 04 16](https://user-images.githubusercontent.com/25996236/147171390-123f4baf-5475-4920-880e-424593d74cde.png)
