### PR TITLE
Add Linux tray menu; Fix tray window position; Fix AppImage APP icon

### DIFF
--- a/src/main/ui/tray/window.ts
+++ b/src/main/ui/tray/window.ts
@@ -11,6 +11,13 @@ import path from 'path'
 
 const makeWindow = () => {
   let win: BrowserWindow | null
+  // Linux AppImage APP can't automatically recognize dock icon, requires special configuration to display correctly
+  let linux_icon = {}
+  if (process.platform === 'linux') {
+    linux_icon = {
+      icon: path.join(__dirname, '/assets/icon.png'),
+    }
+  }
   win = new BrowserWindow({
     frame: false,
     // titleBarStyle: 'hidden',
@@ -30,6 +37,7 @@ const makeWindow = () => {
       preload: path.join(__dirname, 'preload.js'),
       spellcheck: true,
     },
+    ...linux_icon,
   })
 
   win.setVisibleOnAllWorkspaces(true, {


### PR DESCRIPTION
- 给 Linux 桌面环境下添加了 tray 的菜单

Linux 的系统托盘有点奇怪，和其他系统不一样，没有右键，左键，双击等动作，只有一个动作（[这里](https://www.electronjs.org/zh/docs/latest/api/tray)）。不单独配置的话，不管怎么点击，都是一个内容菜单。

再点击这个选项，动作就是其他系统的左键点击。（其他动作的点击行为都一样）

长这样：

![gnome-tray](https://user-images.githubusercontent.com/45233122/159975050-c4118515-8357-4a88-9abc-d3a357efa668.png)

![kde-tray](https://user-images.githubusercontent.com/45233122/159978882-f21313ff-08b5-40c9-807d-3172f982c61d.png)


所以把 Linux 下的菜单改成了这样：

![gnome-new](https://user-images.githubusercontent.com/45233122/159975828-13d91e23-a66c-46ca-8dfe-e59d3c9012f8.png)

![kde-new](https://user-images.githubusercontent.com/45233122/159979000-2fb4a983-fcdf-4a7c-9de1-1d70d1399315.png)


第一个选项，是打开弹出窗口（也就是其他系统的左键单击），其余选项与其他系统保持一致。

---

- 给点击 Tray 的弹出窗口位置做了重新设计

`getPosition()` 在 Linux 中获得的 x, y 只会等于 0，每次点击 tray icon 的菜单，只会显示在屏幕的左上角（用两个屏幕的话，实在是有点太难受）。

![kde-show](https://user-images.githubusercontent.com/45233122/159978221-20963e95-dc0b-4ab8-a15a-83a3fdd43952.png)

`const tray_bounds = tray.getBounds()` 在 Linux 中不生效，无法拿到 tray icon 的位置，好像 Linux 中的 tray 弹窗不能和其他系统一样，刚好显示在 tray icon 的附近，没办法获得到位置。

这里我按照了 Jetbrains Toolbox 在 Linux 中弹窗的方式，每次都显示在系统托盘图标的一端。
比如在 KDE 中，会靠近图标显示在右下角（状态栏在上方的话，就会靠近图标在上方显示）：

![KDE-toolbox](https://user-images.githubusercontent.com/45233122/159978004-ea0e1daa-9ebc-4399-9e3b-d41f117bd403.png)

最后点击弹窗显示位置如下：

![kde-show-new](https://user-images.githubusercontent.com/45233122/159978140-16eb3a12-9d80-469e-80c9-6ee8941aaafe.png)

![xfce-show-new](https://user-images.githubusercontent.com/45233122/159978633-4a863912-e550-430e-a925-b875bc3c7ce5.png)

![gnome-show-new](https://user-images.githubusercontent.com/45233122/159978657-18188f53-174a-4c94-8086-cf5035ac1bbe.png)

---

- 修复了一个使用 AppImage 打包应用是，点击 Tray 弹窗打开应用时，应用无法显示图标的问题。

---

以上修改，均在 gnome，KDE，xfce 三种主流桌面环境进行了测试。


