### PR TITLE
为 linux 平台添加一个选项控制是否使用系统框架

### DIFF
--- a/src/common/default_configs.ts
+++ b/src/common/default_configs.ts
@@ -10,6 +10,7 @@ const configs = {
   // UI
   left_panel_show: true,
   left_panel_width: 270,
+  use_system_window_frame: false,
 
   // preferences
   write_mode: null as WriteModeType,

--- a/src/common/i18n/languages/de.ts
+++ b/src/common/i18n/languages/de.ts
@@ -176,6 +176,7 @@
       'Möchten Sie uns helfen, SwitchHosts zu verbessern, indem Sie regelmäßig anonyme Nutzungsdaten übermitteln?',
     usage_data_title: 'Machen Sie SwitchHosts besser!',
     use_proxy: 'Proxy verwenden',
+    use_system_window_frame: 'System-Fensterrahmen verwenden',
     view: 'Ansicht',
     where_is_my_data: 'Wo sind meine Daten gespeichert?',
     where_is_my_hosts: 'Wo ist meine Hosts-Datei?',

--- a/src/common/i18n/languages/de.ts
+++ b/src/common/i18n/languages/de.ts
@@ -176,7 +176,7 @@
       'Möchten Sie uns helfen, SwitchHosts zu verbessern, indem Sie regelmäßig anonyme Nutzungsdaten übermitteln?',
     usage_data_title: 'Machen Sie SwitchHosts besser!',
     use_proxy: 'Proxy verwenden',
-    use_system_window_frame: 'System-Fensterrahmen verwenden',
+    use_system_window_frame: 'Verwenden Sie den Systemfensterrahmen, ein Neustart der Anwendung ist erforderlich',
     view: 'Ansicht',
     where_is_my_data: 'Wo sind meine Daten gespeichert?',
     where_is_my_hosts: 'Wo ist meine Hosts-Datei?',

--- a/src/common/i18n/languages/en.ts
+++ b/src/common/i18n/languages/en.ts
@@ -176,6 +176,7 @@ export default {
     'Would you like to help us improve SwitchHosts by periodically submitting anonymous usage data?',
   usage_data_title: 'Make SwitchHosts better!',
   use_proxy: 'Use proxy',
+  use_system_window_frame: 'Use system window frame',
   view: 'View',
   where_is_my_data: 'Where is my data stored?',
   where_is_my_hosts: 'Where is my hosts file?',

--- a/src/common/i18n/languages/en.ts
+++ b/src/common/i18n/languages/en.ts
@@ -176,7 +176,7 @@ export default {
     'Would you like to help us improve SwitchHosts by periodically submitting anonymous usage data?',
   usage_data_title: 'Make SwitchHosts better!',
   use_proxy: 'Use proxy',
-  use_system_window_frame: 'Use system window frame',
+  use_system_window_frame: 'Use system window frame, application restart is required',
   view: 'View',
   where_is_my_data: 'Where is my data stored?',
   where_is_my_hosts: 'Where is my hosts file?',

--- a/src/common/i18n/languages/fr.ts
+++ b/src/common/i18n/languages/fr.ts
@@ -177,7 +177,7 @@ export default {
     "Voulez-vous nous aider à améliorer SwitchHosts en soumettant périodiquement vos données d'utilisation de manière anonyme ?",
   usage_data_title: 'Rendez SwitchHosts meilleur !',
   use_proxy: 'Utiliser un proxy',
-  use_system_window_frame: 'Utiliser la bordure de fenêtre du système',
+  use_system_window_frame: 'Utiliser le cadre de la fenêtre système, le redémarrage de l\'application est requis',
   view: 'Vue',
   where_is_my_data: 'Où sont stockées mes données ?',
   where_is_my_hosts: 'Où est mon fichier hosts ?',

--- a/src/common/i18n/languages/fr.ts
+++ b/src/common/i18n/languages/fr.ts
@@ -177,6 +177,7 @@ export default {
     "Voulez-vous nous aider à améliorer SwitchHosts en soumettant périodiquement vos données d'utilisation de manière anonyme ?",
   usage_data_title: 'Rendez SwitchHosts meilleur !',
   use_proxy: 'Utiliser un proxy',
+  use_system_window_frame: 'Utiliser la bordure de fenêtre du système',
   view: 'Vue',
   where_is_my_data: 'Où sont stockées mes données ?',
   where_is_my_hosts: 'Où est mon fichier hosts ?',

--- a/src/common/i18n/languages/zh.ts
+++ b/src/common/i18n/languages/zh.ts
@@ -172,7 +172,7 @@ const lang: LanguageDict = {
     '您愿意发送匿名的使用数据来帮助我们改进 SwitchHosts 吗？数据中不会包含任何隐私信息。',
   usage_data_title: '帮助改进 SwitchHosts',
   use_proxy: '使用代理',
-  use_system_window_frame: '使用系统窗口框架',
+  use_system_window_frame: '使用系统窗口框架，需要重启程序',
   view: '视图',
   where_is_my_data: '我的数据存储在哪里？',
   where_is_my_hosts: '我的 hosts 文件在哪里？',

--- a/src/common/i18n/languages/zh.ts
+++ b/src/common/i18n/languages/zh.ts
@@ -172,6 +172,7 @@ const lang: LanguageDict = {
     '您愿意发送匿名的使用数据来帮助我们改进 SwitchHosts 吗？数据中不会包含任何隐私信息。',
   usage_data_title: '帮助改进 SwitchHosts',
   use_proxy: '使用代理',
+  use_system_window_frame: '使用系统窗口框架',
   view: '视图',
   where_is_my_data: '我的数据存储在哪里？',
   where_is_my_hosts: '我的 hosts 文件在哪里？',

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -46,7 +46,7 @@ const createWindow = async () => {
     minHeight: 200,
     autoHideMenuBar: true,
     titleBarStyle: 'hiddenInset',
-    frame: false,
+    frame: configs.use_system_window_frame || false,
     webPreferences: {
       contextIsolation: true,
       preload: path.join(__dirname, 'preload.js'),

--- a/src/renderer/components/Pref/General.tsx
+++ b/src/renderer/components/Pref/General.tsx
@@ -154,6 +154,19 @@ const General = (props: IProps) => {
         </HStack>
       </FormControl>
 
+      {agent.platform === 'linux' ? (
+        <FormControl>
+          <HStack>
+            <Checkbox
+              isChecked={data.use_system_window_frame}
+              onChange={(e) => onChange({ use_system_window_frame: e.target.checked })}
+            >
+              {lang.use_system_window_frame}
+            </Checkbox>
+          </HStack>
+        </FormControl>
+      ) : null}
+
       {agent.platform === 'darwin' ? (
         <FormControl>
           <HStack>

--- a/src/renderer/components/TopBar/index.tsx
+++ b/src/renderer/components/TopBar/index.tsx
@@ -18,10 +18,11 @@ import styles from './index.less'
 
 interface IProps {
   show_left_panel: boolean
+  use_system_window_frame: boolean
 }
 
 export default (props: IProps) => {
-  const { show_left_panel } = props
+  const { show_left_panel, use_system_window_frame } = props
   const { lang } = useModel('useI18n')
   const { isHostsInTrashcan, current_hosts, isReadOnly } =
     useModel('useHostsData')
@@ -30,7 +31,7 @@ export default (props: IProps) => {
   const show_toggle_switch =
     !show_left_panel && current_hosts && !isHostsInTrashcan(current_hosts.id)
   const show_history = !current_hosts
-  const show_close_button = agent.platform !== 'darwin'
+  const show_close_button = agent.platform === 'linux' && !use_system_window_frame || agent.platform !== 'darwin' && agent.platform !== 'linux'
 
   useEffect(() => {
     setIsOn(!!current_hosts?.on)

--- a/src/renderer/pages/index.tsx
+++ b/src/renderer/pages/index.tsx
@@ -25,6 +25,7 @@ export default () => {
   const { configs } = useModel('useConfigs')
   const [left_width, setLeftWidth] = useState(0)
   const [left_show, setLeftShow] = useState(true)
+  const [use_system_window_frame, setSystemFrame] = useState(false)
   const [show_migration, setShowMigration] = useState(false)
   const toast = useToast()
 
@@ -55,6 +56,7 @@ export default () => {
     setLocale(configs.locale)
     setLeftWidth(configs.left_panel_width)
     setLeftShow(configs.left_panel_show)
+    setSystemFrame(configs.use_system_window_frame)
 
     let theme = configs.theme
     let cls = document.body.className
@@ -114,7 +116,7 @@ export default () => {
 
   return (
     <div className={styles.root}>
-      <TopBar show_left_panel={left_show} />
+      <TopBar show_left_panel={left_show} use_system_window_frame={use_system_window_frame} />
 
       <div>
         <div


### PR DESCRIPTION
由于 linux 平台上使用 frameless 窗口会出现阴影丢失，https://github.com/electron/electron/issues/2380 ，添加一个选项用于控制是否使用 frameless 窗口

resolves #711

todo:
- [x] 使用系统框架时隐藏关闭按钮