### PR TITLE
chore: replace taobao mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ folder contains various configuration information.
 - This command may take several minutes to finish when you run it the first time, as it needs time
   to download dependent files. You can download the dependencies
   manually [here](https://github.com/electron/electron/releases),
-  or [Taobao mirror](https://npm.taobao.org/mirrors/electron/), then save the files to `~/.electron`
+  or [Taobao mirror](https://npmmirror.com/mirrors/electron/), then save the files to `~/.electron`
   . You can check the [Electron Docs](http://electron.atom.io/docs/) for more infomation.
 
 ```bash

--- a/README_cn.md
+++ b/README_cn.md
@@ -48,7 +48,7 @@ SwitchHosts 的数据文件存储于 `~/.SwitchHosts` (Windows 下存储于用�
 - 运行 `npm run build`
 - 运行 `npm run make`，如果一切顺利，可在 `./dist` 目录下找到打包后的文件
 - 首次运行可能需要花费一些时间，因为需要下载相关依赖文件。你也可以从 [这儿](https://github.com/electron/electron/releases)
-  或者 [淘宝镜像](https://npm.taobao.org/mirrors/electron/) 手动下载，并保存到 `~/.electron`
+  或者 [淘宝镜像](https://npmmirror.com/mirrors/electron/) 手动下载，并保存到 `~/.electron`
   目录下。更多信息可访问 [Electron 文档](http://electron.atom.io/docs/)。
 
 ```bash


### PR DESCRIPTION
替换淘宝 npm 镜像，来源于[淘宝 npm 域名即将切换](https://zhuanlan.zhihu.com/p/465424728)