### PR TITLE
Adds the Chocolatey package as a way to install SwitchHosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ links:
 
 - [SwitchHosts Download Page (GitHub release)](https://github.com/oldj/SwitchHosts/releases)
 
+You can also install the built version using the [package manager Chocolatey](https://community.chocolatey.org/packages/switchhosts):
+```powershell
+choco install switchhosts
+```
+
 ## Backup
 
 SwitchHosts stores data at `~/.SwitchHosts` (Or folder `.SwitchHosts` under the current user's home


### PR DESCRIPTION
Hi SwitchHosts devs,

I have created this Pull Request because I have resolved this [request for a Chocolatey package](https://github.com/chocolatey-community/chocolatey-package-requests/issues/1040) and now, we can install **switchhosts** using [Chocolatey](https://community.chocolatey.org/packages/switchhosts).

For now, only the latest version (`4.1.2`) is available on Chocolatey. When new versions will be released, they will, then, be added to the Chocolatey package for users to enjoy. :slightly_smiling_face: 

