### PR TITLE
fix(tree): stale closure in React.memo causing sibling folder collapse

### DIFF
--- a/src/renderer/components/Tree/Tree.test.tsx
+++ b/src/renderer/components/Tree/Tree.test.tsx
@@ -169,3 +169,37 @@ describe('Tree reorder DOM reconciliation', () => {
     expect(after.e).toBe(before.e)
   })
 })
+
+describe('folder collapse (React.memo stale closure)', () => {
+  // Regression for #1014: toggling one folder must not revert a
+  // sibling folder's collapse state. The bug was a stale onNodeChange
+  // closure retained by a memoized (unchanged data) Node, whose
+  // captured tree snapshot rewound siblings on cloneDeep.
+  const folders: ITreeNodeData[] = [
+    { id: 'A', title: 'A', is_collapsed: false, children: [{ id: 'a1', title: 'a1' }] },
+    { id: 'B', title: 'B', is_collapsed: false, children: [{ id: 'b1', title: 'b1' }] },
+  ]
+
+  const arrowOf = (container: HTMLElement, id: string): HTMLElement => {
+    const el = container.querySelector(`[data-id="${id}"] [data-collapsed]`)
+    if (!el) throw new Error(`collapse arrow for #${id} not found`)
+    return el as HTMLElement
+  }
+
+  const collapsedOf = (tree: ITreeNodeData[], id: string): boolean | undefined =>
+    tree.find((n) => n.id === id)?.is_collapsed
+
+  it('collapsing one folder does not revert a sibling folder', () => {
+    const onChange = vi.fn()
+    const { container } = render(<Harness initial_data={folders} onChange={onChange} />)
+
+    fireEvent.click(arrowOf(container, 'A'))
+    expect(collapsedOf(lastReceivedTree(onChange), 'A')).toBe(true)
+
+    // Collapsing B must not resurrect A's previous (expanded) state.
+    fireEvent.click(arrowOf(container, 'B'))
+    const tree = lastReceivedTree(onChange)
+    expect(collapsedOf(tree, 'B')).toBe(true)
+    expect(collapsedOf(tree, 'A')).toBe(true)
+  })
+})

--- a/src/renderer/components/Tree/Tree.tsx
+++ b/src/renderer/components/Tree/Tree.tsx
@@ -6,7 +6,7 @@
 import { ITreeNodeData, NodeIdType } from '@common/tree'
 import clsx from 'clsx'
 import lodash from 'lodash'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { canBeSelected, flatten, getNodeById, selectTo, treeMoveNode } from './fn'
 import Node, { NodeUpdate } from './Node'
 import styles from './style.module.scss'
@@ -41,6 +41,15 @@ const Tree = (props: ITreeProps) => {
   const [dropTargetId, setDropTargetId] = useState<NodeIdType | null>(null)
   const [selectedIds, setSelectedIds] = useState<NodeIdType[]>(props.selectedIds || [])
   const [dropWhere, setDropWhere] = useState<DropWhereType | null>(null)
+
+  // Stable refs so onNodeChange (memoized with []) always reads the
+  // latest tree and onChange, avoiding the React.memo stale-closure
+  // bug where a node whose data didn't change keeps an old handler
+  // whose captured tree lacks collapse states from sibling operations.
+  const treeRef = useRef(tree)
+  treeRef.current = tree
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- local working copy; mutated mid-drag and reset when source data changes
@@ -93,15 +102,15 @@ const Tree = (props: ITreeProps) => {
     if (onChange) onChange(tree)
   }
 
-  const onNodeChange = (id: NodeIdType, data: Partial<ITreeNodeData>) => {
-    const tree2 = lodash.cloneDeep(tree)
+  const onNodeChange = useCallback((id: NodeIdType, data: Partial<ITreeNodeData>) => {
+    const tree2 = lodash.cloneDeep(treeRef.current)
     const node = getNodeById(tree2, id)
     if (!node) return
 
     Object.assign(node, data)
     setTree(tree2)
-    onTreeChange(tree2)
-  }
+    onChangeRef.current?.(tree2)
+  }, [])
 
   const onSelectOne = (id: NodeIdType, multipleType: MultipleSelectType = 0) => {
     // console.log('multipleType:', multipleType, 'ids:', selectedIds, 'id:', id)

--- a/src/renderer/components/Tree/Tree.tsx
+++ b/src/renderer/components/Tree/Tree.tsx
@@ -47,9 +47,11 @@ const Tree = (props: ITreeProps) => {
   // bug where a node whose data didn't change keeps an old handler
   // whose captured tree lacks collapse states from sibling operations.
   const treeRef = useRef(tree)
-  treeRef.current = tree
   const onChangeRef = useRef(onChange)
-  onChangeRef.current = onChange
+  useEffect(() => {
+    treeRef.current = tree
+    onChangeRef.current = onChange
+  })
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- local working copy; mutated mid-drag and reset when source data changes


### PR DESCRIPTION
## 问题

展开一个文件夹后，其他已展开的文件夹被自动折叠。Closes #1014。

## 根因

`Node.tsx` 使用 `React.memo`，其 `isEqual` 比较函数不检查 `onChange`（即 `onNodeChange`）prop 是否变化。当一个 Node 的 `data` 未变时，React.memo 复用旧 VNode，保留了旧的 `onNodeChange` handler。

旧 handler 的闭包中 `tree` 是创建时的快照，不包含之后其他文件夹的折叠/展开操作。当该 handler 被调用时，`cloneDeep(旧tree)` 将其他文件夹的状态回退到过去的值。

### 触发链路

```
1. 初始：A 折叠，B 展开，C 展开
2. 折叠 C → Tree 重渲染，onNodeChange_2 创建
3. A 的 data 未变 → isEqual=true → A 保留旧的 onNodeChange_1
4. 展开 A → 触发 onNodeChange_1（闭包中 tree=[A折叠, B展开, C展开]）
5. cloneDeep(旧tree) → A 展开，C 也被「恢复」为展开
```

## 修复

`Tree.tsx` 中 `onNodeChange` 改为 `useCallback` + `ref`：

```ts
const treeRef = useRef(tree)
treeRef.current = tree
const onChangeRef = useRef(onChange)
onChangeRef.current = onChange

const onNodeChange = useCallback((id, data) => {
  const tree2 = lodash.cloneDeep(treeRef.current)
  // ...
  onChangeRef.current?.(tree2)
}, [])
```

`useCallback` 空依赖保证函数引用永不变（React.memo 稳定），内部通过 ref 始终读取最新 `tree` 和 `onChange`。