### PR TITLE
feat: add hosts to system tray menu

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -420,7 +420,7 @@ pub async fn get_content_of_list(
 }
 
 #[tauri::command]
-pub async fn set_list(state: State<'_, AppState>, args: Args) -> Result<Value, StorageError> {
+pub async fn set_list(app: AppHandle<Wry>, state: State<'_, AppState>, args: Args) -> Result<Value, StorageError> {
     state.require_data_dir_usable()?;
     let list = args.into_iter().next().unwrap_or(Value::Null);
     let root = match list {
@@ -437,11 +437,13 @@ pub async fn set_list(state: State<'_, AppState>, args: Args) -> Result<Value, S
     let mut m = load_manifest(&state).unwrap_or_default();
     m.root = root;
     save_manifest(&state, &m)?;
+    tray::refresh_menu(&app);
     Ok(Value::Null)
 }
 
 #[tauri::command]
 pub async fn move_to_trashcan(
+    app: AppHandle<Wry>,
     state: State<'_, AppState>,
     args: Args,
 ) -> Result<Value, StorageError> {
@@ -449,11 +451,13 @@ pub async fn move_to_trashcan(
     let id = arg_str(&args, 0, "id")?.to_string();
     let _guard = state.store_lock.lock().expect("store lock poisoned");
     move_ids_to_trashcan(&state, &[id])?;
+    tray::refresh_menu(&app);
     Ok(Value::Null)
 }
 
 #[tauri::command]
 pub async fn move_many_to_trashcan(
+    app: AppHandle<Wry>,
     state: State<'_, AppState>,
     args: Args,
 ) -> Result<Value, StorageError> {
@@ -473,6 +477,7 @@ pub async fn move_many_to_trashcan(
     };
     let _guard = state.store_lock.lock().expect("store lock poisoned");
     move_ids_to_trashcan(&state, &ids)?;
+    tray::refresh_menu(&app);
     Ok(Value::Null)
 }
 
@@ -553,6 +558,7 @@ pub async fn delete_item_from_trashcan(
 
 #[tauri::command]
 pub async fn restore_item_from_trashcan(
+    app: AppHandle<Wry>,
     state: State<'_, AppState>,
     args: Args,
 ) -> Result<Value, StorageError> {
@@ -581,6 +587,7 @@ pub async fn restore_item_from_trashcan(
     manifest::insert_node(&mut m.root, node, parent_id.as_deref());
     save_manifest(&state, &m)?;
     save_trashcan(&state, &t)?;
+    tray::refresh_menu(&app);
     Ok(json!(true))
 }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -22,7 +22,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::json;
 use tauri::image::Image;
-use tauri::menu::{Menu, MenuBuilder, MenuItemBuilder};
+use tauri::menu::{Menu, MenuBuilder, MenuItemBuilder, CheckMenuItemBuilder, SubmenuBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::webview::WebviewWindowBuilder;
 use tauri::{
@@ -241,10 +241,16 @@ fn build_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Menu<R>, tauri::Error> {
         .build(app)?;
     let quit = MenuItemBuilder::with_id(MENU_ID_QUIT, labels.quit).build(app)?;
 
-    let menu_builder = MenuBuilder::new(app)
+    let mut menu_builder = MenuBuilder::new(app)
         .item(&show_main)
         .item(&version)
         .separator();
+
+    let state = app.state::<AppState>();
+    if let Ok(manifest) = Manifest::load(&state.paths) {
+        menu_builder = build_hosts_menu_items(app, menu_builder, &manifest.root)?;
+        menu_builder = menu_builder.separator();
+    }
 
     #[cfg(target_os = "macos")]
     let menu_builder = {
@@ -259,6 +265,62 @@ fn build_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Menu<R>, tauri::Error> {
     };
 
     menu_builder.item(&quit).build()
+}
+
+fn build_hosts_menu_items<'a, R: Runtime>(
+    app: &'a AppHandle<R>,
+    mut builder: MenuBuilder<'a, R, AppHandle<R>>,
+    nodes: &[serde_json::Value],
+) -> Result<MenuBuilder<'a, R, AppHandle<R>>, tauri::Error> {
+    for node in nodes {
+        let title = node.get("title").and_then(|v| v.as_str()).unwrap_or("");
+        let id = node.get("id").and_then(|v| v.as_str()).unwrap_or("");
+        let is_on = node.get("on").and_then(|v| v.as_bool()).unwrap_or(false);
+        let kind = node.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        
+        if kind == "folder" {
+            let mut submenu_builder = SubmenuBuilder::new(app, title);
+            if let Some(children) = node.get("children").and_then(|v| v.as_array()) {
+                submenu_builder = build_hosts_submenu_items(app, submenu_builder, children)?;
+            }
+            builder = builder.item(&submenu_builder.build()?);
+        } else if kind == "local" || kind == "remote" {
+            let menu_id = format!("tray-host-{}", id);
+            let item = CheckMenuItemBuilder::with_id(&menu_id, title)
+                .checked(is_on)
+                .build(app)?;
+            builder = builder.item(&item);
+        }
+    }
+    Ok(builder)
+}
+
+fn build_hosts_submenu_items<'a, R: Runtime>(
+    app: &'a AppHandle<R>,
+    mut builder: SubmenuBuilder<'a, R, AppHandle<R>>,
+    nodes: &[serde_json::Value],
+) -> Result<SubmenuBuilder<'a, R, AppHandle<R>>, tauri::Error> {
+    for node in nodes {
+        let title = node.get("title").and_then(|v| v.as_str()).unwrap_or("");
+        let id = node.get("id").and_then(|v| v.as_str()).unwrap_or("");
+        let is_on = node.get("on").and_then(|v| v.as_bool()).unwrap_or(false);
+        let kind = node.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        
+        if kind == "folder" {
+            let mut submenu_builder = SubmenuBuilder::new(app, title);
+            if let Some(children) = node.get("children").and_then(|v| v.as_array()) {
+                submenu_builder = build_hosts_submenu_items(app, submenu_builder, children)?;
+            }
+            builder = builder.item(&submenu_builder.build()?);
+        } else if kind == "local" || kind == "remote" {
+            let menu_id = format!("tray-host-{}", id);
+            let item = CheckMenuItemBuilder::with_id(&menu_id, title)
+                .checked(is_on)
+                .build(app)?;
+            builder = builder.item(&item);
+        }
+    }
+    Ok(builder)
 }
 
 #[cfg(target_os = "macos")]
@@ -276,6 +338,18 @@ fn read_hide_dock_icon<R: Runtime>(app: &AppHandle<R>) -> bool {
 /// Called from the global `on_menu_event` handler in `lib.rs` when an
 /// id starts with `tray-`. Returns `true` if the id was handled here.
 pub fn handle_menu_event<R: Runtime + 'static>(app: &AppHandle<R>, id: &str) -> bool {
+    if id.starts_with("tray-host-") {
+        let host_id = &id["tray-host-".len()..];
+        let state = app.state::<AppState>();
+        if let Ok(manifest) = Manifest::load(&state.paths) {
+            if let Some(node) = crate::storage::manifest::find_node(&manifest.root, host_id) {
+                let current_on = node.get("on").and_then(|v| v.as_bool()).unwrap_or(false);
+                let _ = app.emit("toggle_item", json!({ "_args": [host_id, !current_on] }));
+            }
+        }
+        return true;
+    }
+
     match id {
         MENU_ID_SHOW_MAIN => {
             show_main_window(app);


### PR DESCRIPTION
  ## Describe the changes
This PR fixes the issue where the system tray native menu does not show the configured hosts. It builds the native hosts menu from `manifest.json` using Tauri's native tray

  builder, adds event listening for toggling hosts directly from the tray, and dynamically refreshes the menu when the hosts list is modified or items are moved to the trash.

 ## Related issue
Fixes #1020