### PR TITLE
feat(tray): add hosts entries to system tray menu with backend toggle

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1141,8 +1141,13 @@ pub async fn hide_main_window<R: Runtime>(
 
 #[tauri::command]
 pub async fn focus_main_window<R: Runtime>(app: AppHandle<R>, _args: Args) -> Value {
-    lifecycle::show_main_window(&app);
+    crate::lifecycle::show_main_window(&app);
     Value::Null
+}
+
+#[tauri::command]
+pub async fn is_main_window_alive<R: Runtime>(app: AppHandle<R>) -> bool {
+    app.get_webview_window(crate::lifecycle::MAIN_WINDOW_LABEL).is_some()
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -668,6 +668,19 @@ pub async fn apply_hosts_selection<R: Runtime>(
         }
     };
 
+    Ok(apply_aggregated_content(&app, state.inner(), content).await)
+}
+
+/// Apply already-aggregated hosts content to the system file, persist
+/// apply history, refresh the tray title, and run cmd-after-apply.
+/// Shared by the renderer-driven `apply_hosts_selection` command and
+/// the backend-only tray toggle path so both traverse an identical
+/// pipeline. Returns the renderer-facing result `Value`.
+pub async fn apply_aggregated_content<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &AppState,
+    content: String,
+) -> Value {
     let (write_mode, history_limit, cmd_after_apply) = {
         let cfg = state.config.lock().expect("config mutex poisoned");
         (
@@ -684,11 +697,11 @@ pub async fn apply_hosts_selection<R: Runtime>(
     let outcome = match hosts_apply::apply_to_system_hosts(&content, &write_mode) {
         Ok(o) => o,
         Err(HostsApplyError::Cancelled) => {
-            return Ok(HostsApplyError::Cancelled.into_renderer_value());
+            return HostsApplyError::Cancelled.into_renderer_value();
         }
         Err(e) => {
             log::warn!("apply failed: {e}");
-            return Ok(e.into_renderer_value());
+            return e.into_renderer_value();
         }
     };
 
@@ -736,7 +749,7 @@ pub async fn apply_hosts_selection<R: Runtime>(
     // Push the freshest tray title to the menubar without waiting on
     // the renderer to call `update_tray_title` — the user expects to
     // see the title flip immediately after an apply.
-    if let Err(e) = tray::refresh_title(&app, state.inner()) {
+    if let Err(e) = tray::refresh_title(app, state) {
         log::warn!("failed to refresh tray title: {e}");
     }
 
@@ -761,11 +774,85 @@ pub async fn apply_hosts_selection<R: Runtime>(
         }
     }
 
-    Ok(json!({
+    json!({
         "success": true,
         "old_content": outcome.previous_content,
         "new_content": outcome.new_content,
-    }))
+    })
+}
+
+/// Toggle a single hosts item's on-state from a native tray-menu click
+/// and apply the result to the system — entirely in the backend, with
+/// no dependency on any webview being alive. This is what makes tray
+/// toggling work in lightweight mode where the main window has been
+/// destroyed.
+///
+/// Runs the mutation + apply on a background task (the privileged write
+/// may block at the OS auth prompt) and mirrors the renderer's
+/// `onToggleItem` gate: when no write mode is configured we can't apply
+/// silently, so we surface the main window instead.
+pub fn toggle_host_from_tray<R: Runtime>(app: &AppHandle<R>, id: &str, on: bool) {
+    let state = app.state::<AppState>();
+    let write_mode_empty = state
+        .config
+        .lock()
+        .map(|c| c.write_mode.is_empty())
+        .unwrap_or(true);
+    if write_mode_empty {
+        // No write mode configured — can't silently apply. Surface the
+        // main window (and ask it to prompt) like the renderer does.
+        lifecycle::show_main_window(app);
+        let _ = app.emit("show_set_write_mode", json!({ "_args": [{ "id": id, "on": on }] }));
+        return;
+    }
+
+    let app = app.clone();
+    let id = id.to_string();
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = toggle_host_and_apply(&app, &id, on).await {
+            log::warn!("tray toggle failed: {e}");
+        }
+    });
+}
+
+async fn toggle_host_and_apply<R: Runtime>(
+    app: &AppHandle<R>,
+    id: &str,
+    on: bool,
+) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    state.require_data_dir_usable().map_err(|e| e.to_string())?;
+
+    let (choice_mode, multi_switch_all, remove_duplicate) = {
+        let cfg = state.config.lock().expect("config mutex poisoned");
+        (
+            cfg.choice_mode,
+            cfg.multi_chose_folder_switch_all,
+            cfg.remove_duplicate_records,
+        )
+    };
+
+    // Mutate the manifest on-state under the store lock, then release it
+    // before the potentially long-blocking privileged system write.
+    let new_list = {
+        let _guard = state.store_lock.lock().expect("store lock poisoned");
+        let mut m = load_manifest(&state).unwrap_or_default();
+        manifest::set_on_state_of_item(&mut m.root, id, on, choice_mode, multi_switch_all);
+        save_manifest(&state, &m).map_err(|e| e.to_string())?;
+        m.root.clone()
+    };
+
+    let content =
+        hosts_apply::aggregate_selected_content(&new_list, &state.paths, remove_duplicate)
+            .map_err(|e| e.to_string())?;
+
+    let _ = apply_aggregated_content(app, state.inner(), content).await;
+
+    // Refresh tray menu checkmarks and let any live window reload its list.
+    tray::refresh_menu(app);
+    let _ = app.emit("reload_list", json!({ "_args": [] }));
+
+    Ok(())
 }
 
 // ---- privileged helper (macOS SMAppService) --------------------------------

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -420,7 +420,7 @@ pub async fn get_content_of_list(
 }
 
 #[tauri::command]
-pub async fn set_list(state: State<'_, AppState>, args: Args) -> Result<Value, StorageError> {
+pub async fn set_list(app: AppHandle<Wry>, state: State<'_, AppState>, args: Args) -> Result<Value, StorageError> {
     state.require_data_dir_usable()?;
     let list = args.into_iter().next().unwrap_or(Value::Null);
     let root = match list {
@@ -437,11 +437,13 @@ pub async fn set_list(state: State<'_, AppState>, args: Args) -> Result<Value, S
     let mut m = load_manifest(&state).unwrap_or_default();
     m.root = root;
     save_manifest(&state, &m)?;
+    tray::refresh_menu(&app);
     Ok(Value::Null)
 }
 
 #[tauri::command]
 pub async fn move_to_trashcan(
+    app: AppHandle<Wry>,
     state: State<'_, AppState>,
     args: Args,
 ) -> Result<Value, StorageError> {
@@ -449,11 +451,13 @@ pub async fn move_to_trashcan(
     let id = arg_str(&args, 0, "id")?.to_string();
     let _guard = state.store_lock.lock().expect("store lock poisoned");
     move_ids_to_trashcan(&state, &[id])?;
+    tray::refresh_menu(&app);
     Ok(Value::Null)
 }
 
 #[tauri::command]
 pub async fn move_many_to_trashcan(
+    app: AppHandle<Wry>,
     state: State<'_, AppState>,
     args: Args,
 ) -> Result<Value, StorageError> {
@@ -473,6 +477,7 @@ pub async fn move_many_to_trashcan(
     };
     let _guard = state.store_lock.lock().expect("store lock poisoned");
     move_ids_to_trashcan(&state, &ids)?;
+    tray::refresh_menu(&app);
     Ok(Value::Null)
 }
 
@@ -553,6 +558,7 @@ pub async fn delete_item_from_trashcan(
 
 #[tauri::command]
 pub async fn restore_item_from_trashcan(
+    app: AppHandle<Wry>,
     state: State<'_, AppState>,
     args: Args,
 ) -> Result<Value, StorageError> {
@@ -581,6 +587,7 @@ pub async fn restore_item_from_trashcan(
     manifest::insert_node(&mut m.root, node, parent_id.as_deref());
     save_manifest(&state, &m)?;
     save_trashcan(&state, &t)?;
+    tray::refresh_menu(&app);
     Ok(json!(true))
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -531,6 +531,7 @@ pub fn run() {
             // window / misc
             commands::hide_main_window,
             commands::focus_main_window,
+            commands::is_main_window_alive,
             commands::quit_app,
             commands::update_tray_title,
             commands::open_url,

--- a/src-tauri/src/storage/manifest.rs
+++ b/src-tauri/src/storage/manifest.rs
@@ -208,6 +208,184 @@ fn node_children_mut(node: &mut Value) -> Option<&mut Vec<Value>> {
     node.get_mut("children").and_then(Value::as_array_mut)
 }
 
+fn node_is_folder(node: &Value) -> bool {
+    node.get("type").and_then(Value::as_str) == Some("folder")
+}
+
+/// Read a node's `folder_mode` (0 = default / inherit, 1 = single,
+/// 2 = multiple). Missing / non-numeric → 0, mirroring the renderer's
+/// `parent.folder_mode || defaultChoiceMode` falsy-coalescing.
+fn node_folder_mode(node: &Value) -> u8 {
+    node.get("folder_mode").and_then(Value::as_u64).unwrap_or(0) as u8
+}
+
+fn set_node_on(node: &mut Value, on: bool) {
+    if let Some(obj) = node.as_object_mut() {
+        obj.insert("on".to_string(), Value::Bool(on));
+    }
+}
+
+/// Mutable twin of `find_node`.
+fn find_node_mut<'a>(nodes: &'a mut [Value], id: &str) -> Option<&'a mut Value> {
+    for node in nodes.iter_mut() {
+        if node_id(node) == Some(id) {
+            return Some(node);
+        }
+        if let Some(children) = node_children_mut(node) {
+            if let Some(found) = find_node_mut(children, id) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+/// Whether `id` is a direct child of the root forest.
+fn is_in_top_level(nodes: &[Value], id: &str) -> bool {
+    nodes.iter().any(|n| node_id(n) == Some(id))
+}
+
+/// Id of the folder that directly contains `id`, or `None` when `id`
+/// lives at the top level (mirrors renderer `getParentOfItem`).
+fn parent_id_of(nodes: &[Value], id: &str) -> Option<String> {
+    if is_in_top_level(nodes, id) {
+        return None;
+    }
+    fn rec(nodes: &[Value], id: &str) -> Option<String> {
+        for node in nodes {
+            if let Some(children) = node_children(node) {
+                if children.iter().any(|c| node_id(c) == Some(id)) {
+                    return node_id(node).map(String::from);
+                }
+                if let Some(found) = rec(children, id) {
+                    return Some(found);
+                }
+            }
+        }
+        None
+    }
+    rec(nodes, id)
+}
+
+/// Port of renderer `switchFolderChild`: cascade `on` to every
+/// descendant of a folder, unless the folder is in single-select mode
+/// (`folder_mode === 1`), which owns its own exclusivity.
+fn switch_folder_child(item: &mut Value, on: bool) {
+    if !node_is_folder(item) || node_folder_mode(item) == 1 {
+        return;
+    }
+    if let Some(children) = node_children_mut(item) {
+        for child in children.iter_mut() {
+            set_node_on(child, on);
+            if node_is_folder(child) {
+                switch_folder_child(child, on);
+            }
+        }
+    }
+}
+
+/// Port of renderer `switchItemParentIsON`: walk from `id` up through
+/// its folder ancestors, keeping each parent's `on` in sync with its
+/// children. Stops at the first single-select ancestor (`folder_mode
+/// === 1`), which manages its own state.
+fn switch_item_parent_is_on(nodes: &mut Vec<Value>, id: &str, on: bool) {
+    let mut current = id.to_string();
+    while let Some(pid) = parent_id_of(nodes, &current) {
+        if find_node(nodes, &pid).map(|p| node_folder_mode(&p)) == Some(1) {
+            return;
+        }
+        if !on {
+            if let Some(parent) = find_node_mut(nodes, &pid) {
+                set_node_on(parent, false);
+            }
+        } else if let Some(all_on) = find_node(nodes, &pid).and_then(|p| {
+            p.get("children").and_then(Value::as_array).map(|ch| {
+                ch.iter()
+                    .all(|c| c.get("on").and_then(Value::as_bool).unwrap_or(false))
+            })
+        }) {
+            if let Some(parent) = find_node_mut(nodes, &pid) {
+                set_node_on(parent, all_on);
+            }
+        }
+        if is_in_top_level(nodes, &pid) {
+            break;
+        }
+        current = pid;
+    }
+}
+
+/// In-place Rust port of renderer `setOnStateOfItem`
+/// (`src/common/hostsFn.ts`). Sets the on-state of `id`, applying
+/// choice-mode / folder-mode single-selection exclusion and the
+/// optional folder cascade so that tray, HTTP-API, and renderer
+/// toggles all produce byte-for-byte identical trees.
+///
+/// `default_choice_mode` is the global `choice_mode` config value
+/// (0 = default, 1 = single, 2 = multiple); it only excludes siblings
+/// when equal to 1. Folders may override it via their own
+/// `folder_mode`.
+pub fn set_on_state_of_item(
+    nodes: &mut Vec<Value>,
+    id: &str,
+    on: bool,
+    default_choice_mode: u8,
+    multi_chose_folder_switch_all: bool,
+) {
+    let item_is_top = is_in_top_level(nodes, id);
+
+    {
+        let Some(item) = find_node_mut(nodes, id) else {
+            return;
+        };
+        set_node_on(item, on);
+        if multi_chose_folder_switch_all {
+            switch_folder_child(item, on);
+        }
+    }
+
+    if multi_chose_folder_switch_all && !item_is_top {
+        switch_item_parent_is_on(nodes, id, on);
+    }
+
+    if !on {
+        return;
+    }
+
+    if item_is_top {
+        if default_choice_mode == 1 {
+            for node in nodes.iter_mut() {
+                if node_id(node) != Some(id) {
+                    set_node_on(node, false);
+                    if multi_chose_folder_switch_all {
+                        switch_folder_child(node, false);
+                    }
+                }
+            }
+        }
+        return;
+    }
+
+    if let Some(pid) = parent_id_of(nodes, id) {
+        let folder_mode = find_node(nodes, &pid).map(|p| node_folder_mode(&p)).unwrap_or(0);
+        let effective = if folder_mode != 0 { folder_mode } else { default_choice_mode };
+        if effective == 1 {
+            if let Some(parent) = find_node_mut(nodes, &pid) {
+                if let Some(children) = node_children_mut(parent) {
+                    for child in children.iter_mut() {
+                        if node_id(child) != Some(id) {
+                            set_node_on(child, false);
+                            if multi_chose_folder_switch_all {
+                                switch_folder_child(child, false);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Walk the tree and collect the ids of every `local`/`remote` node
 /// reachable from the root. Used by the export command to know which
 /// `entries/<id>.hosts` files to inline into the backup JSON.
@@ -222,5 +400,125 @@ pub fn collect_content_ids(nodes: &[Value], out: &mut Vec<String>) {
         if let Some(children) = node_children(node) {
             collect_content_ids(children, out);
         }
+    }
+}
+
+#[cfg(test)]
+mod set_on_tests {
+    use super::*;
+
+    // root
+    // ├── a (local, on)
+    // ├── b (local, off)
+    // └── f (folder, off)
+    //     ├── c (local, off)
+    //     └── d (local, on)
+    fn fixture() -> Vec<Value> {
+        json!([
+            { "id": "a", "type": "local", "on": true },
+            { "id": "b", "type": "local", "on": false },
+            {
+                "id": "f",
+                "type": "folder",
+                "on": false,
+                "children": [
+                    { "id": "c", "type": "local", "on": false },
+                    { "id": "d", "type": "local", "on": true },
+                ]
+            },
+        ])
+        .as_array()
+        .cloned()
+        .unwrap()
+    }
+
+    fn on_of(nodes: &[Value], id: &str) -> bool {
+        find_node(nodes, id)
+            .and_then(|n| n.get("on").and_then(Value::as_bool))
+            .unwrap()
+    }
+
+    #[test]
+    fn multiple_mode_does_not_exclude_siblings() {
+        let mut nodes = fixture();
+        // choice_mode = 2 (multiple): turning b on leaves a on.
+        set_on_state_of_item(&mut nodes, "b", true, 2, false);
+        assert!(on_of(&nodes, "a"));
+        assert!(on_of(&nodes, "b"));
+    }
+
+    #[test]
+    fn single_mode_top_level_excludes_other_top_level_items() {
+        let mut nodes = fixture();
+        // choice_mode = 1 (single): turning b on turns a (and folder f) off.
+        set_on_state_of_item(&mut nodes, "b", true, 1, false);
+        assert!(on_of(&nodes, "b"));
+        assert!(!on_of(&nodes, "a"));
+        assert!(!on_of(&nodes, "f"));
+    }
+
+    #[test]
+    fn turning_off_never_excludes_siblings() {
+        let mut nodes = fixture();
+        set_on_state_of_item(&mut nodes, "a", false, 1, false);
+        assert!(!on_of(&nodes, "a"));
+        // b was already off; d inside folder stays on.
+        assert!(on_of(&nodes, "d"));
+    }
+
+    #[test]
+    fn folder_single_mode_excludes_only_within_folder() {
+        let mut nodes = fixture();
+        // Give folder f its own single-select mode.
+        find_node_mut(&mut nodes, "f")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .insert("folder_mode".into(), json!(1));
+        // Turn c on: d (its sibling in f) goes off, top-level a stays on.
+        set_on_state_of_item(&mut nodes, "c", true, 2, false);
+        assert!(on_of(&nodes, "c"));
+        assert!(!on_of(&nodes, "d"));
+        assert!(on_of(&nodes, "a"));
+    }
+
+    #[test]
+    fn folder_inherits_global_single_mode_when_folder_mode_is_default() {
+        let mut nodes = fixture();
+        // folder_mode absent (0/default) → inherit global choice_mode = 1.
+        set_on_state_of_item(&mut nodes, "c", true, 1, false);
+        assert!(on_of(&nodes, "c"));
+        assert!(!on_of(&nodes, "d"));
+    }
+
+    #[test]
+    fn multi_switch_all_cascades_folder_children_and_updates_parent() {
+        let mut nodes = fixture();
+        // Turn the folder on with cascade → both children on, folder on.
+        set_on_state_of_item(&mut nodes, "f", true, 2, true);
+        assert!(on_of(&nodes, "f"));
+        assert!(on_of(&nodes, "c"));
+        assert!(on_of(&nodes, "d"));
+    }
+
+    #[test]
+    fn multi_switch_all_syncs_parent_off_when_a_child_turns_off() {
+        let mut nodes = fixture();
+        // d is on, c is off → folder currently off. Turn c on with
+        // cascade: all children on ⇒ parent folder flips on.
+        set_on_state_of_item(&mut nodes, "c", true, 2, true);
+        assert!(on_of(&nodes, "f"));
+        // Now turn d off with cascade: parent must flip off.
+        set_on_state_of_item(&mut nodes, "d", false, 2, true);
+        assert!(!on_of(&nodes, "f"));
+    }
+
+    #[test]
+    fn missing_id_is_a_noop() {
+        let mut nodes = fixture();
+        set_on_state_of_item(&mut nodes, "nope", true, 1, false);
+        // Nothing changed.
+        assert!(on_of(&nodes, "a"));
+        assert!(!on_of(&nodes, "b"));
     }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -344,7 +344,14 @@ pub fn handle_menu_event<R: Runtime + 'static>(app: &AppHandle<R>, id: &str) -> 
         if let Ok(manifest) = Manifest::load(&state.paths) {
             if let Some(node) = crate::storage::manifest::find_node(&manifest.root, host_id) {
                 let current_on = node.get("on").and_then(|v| v.as_bool()).unwrap_or(false);
-                let _ = app.emit("toggle_item", json!({ "_args": [host_id, !current_on] }));
+                let main_win = app.get_webview_window(crate::lifecycle::MAIN_WINDOW_LABEL);
+                if main_win.is_some() {
+                    let _ = app.emit("toggle_item", json!({ "_args": [host_id, !current_on] }));
+                } else if let Some(tray_win) = app.get_webview_window("tray_window") {
+                    let _ = tray_win.emit("tray_toggle_item", json!({ "_args": [host_id, !current_on] }));
+                } else {
+                    crate::lifecycle::show_main_window(app);
+                }
             }
         }
         return true;

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -22,7 +22,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::json;
 use tauri::image::Image;
-use tauri::menu::{Menu, MenuBuilder, MenuItemBuilder};
+use tauri::menu::{Menu, MenuBuilder, MenuItemBuilder, CheckMenuItemBuilder, SubmenuBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::webview::WebviewWindowBuilder;
 use tauri::{
@@ -241,10 +241,16 @@ fn build_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Menu<R>, tauri::Error> {
         .build(app)?;
     let quit = MenuItemBuilder::with_id(MENU_ID_QUIT, labels.quit).build(app)?;
 
-    let menu_builder = MenuBuilder::new(app)
+    let mut menu_builder = MenuBuilder::new(app)
         .item(&show_main)
         .item(&version)
         .separator();
+
+    let state = app.state::<AppState>();
+    if let Ok(manifest) = Manifest::load(&state.paths) {
+        menu_builder = build_hosts_menu_items(app, menu_builder, &manifest.root)?;
+        menu_builder = menu_builder.separator();
+    }
 
     #[cfg(target_os = "macos")]
     let menu_builder = {
@@ -259,6 +265,62 @@ fn build_menu<R: Runtime>(app: &AppHandle<R>) -> Result<Menu<R>, tauri::Error> {
     };
 
     menu_builder.item(&quit).build()
+}
+
+fn build_hosts_menu_items<'a, R: Runtime>(
+    app: &'a AppHandle<R>,
+    mut builder: MenuBuilder<'a, R, AppHandle<R>>,
+    nodes: &[serde_json::Value],
+) -> Result<MenuBuilder<'a, R, AppHandle<R>>, tauri::Error> {
+    for node in nodes {
+        let title = node.get("title").and_then(|v| v.as_str()).unwrap_or("");
+        let id = node.get("id").and_then(|v| v.as_str()).unwrap_or("");
+        let is_on = node.get("on").and_then(|v| v.as_bool()).unwrap_or(false);
+        let kind = node.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        
+        if kind == "folder" {
+            let mut submenu_builder = SubmenuBuilder::new(app, title);
+            if let Some(children) = node.get("children").and_then(|v| v.as_array()) {
+                submenu_builder = build_hosts_submenu_items(app, submenu_builder, children)?;
+            }
+            builder = builder.item(&submenu_builder.build()?);
+        } else if kind == "local" || kind == "remote" {
+            let menu_id = format!("tray-host-{}", id);
+            let item = CheckMenuItemBuilder::with_id(&menu_id, title)
+                .checked(is_on)
+                .build(app)?;
+            builder = builder.item(&item);
+        }
+    }
+    Ok(builder)
+}
+
+fn build_hosts_submenu_items<'a, R: Runtime>(
+    app: &'a AppHandle<R>,
+    mut builder: SubmenuBuilder<'a, R, AppHandle<R>>,
+    nodes: &[serde_json::Value],
+) -> Result<SubmenuBuilder<'a, R, AppHandle<R>>, tauri::Error> {
+    for node in nodes {
+        let title = node.get("title").and_then(|v| v.as_str()).unwrap_or("");
+        let id = node.get("id").and_then(|v| v.as_str()).unwrap_or("");
+        let is_on = node.get("on").and_then(|v| v.as_bool()).unwrap_or(false);
+        let kind = node.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        
+        if kind == "folder" {
+            let mut submenu_builder = SubmenuBuilder::new(app, title);
+            if let Some(children) = node.get("children").and_then(|v| v.as_array()) {
+                submenu_builder = build_hosts_submenu_items(app, submenu_builder, children)?;
+            }
+            builder = builder.item(&submenu_builder.build()?);
+        } else if kind == "local" || kind == "remote" {
+            let menu_id = format!("tray-host-{}", id);
+            let item = CheckMenuItemBuilder::with_id(&menu_id, title)
+                .checked(is_on)
+                .build(app)?;
+            builder = builder.item(&item);
+        }
+    }
+    Ok(builder)
 }
 
 #[cfg(target_os = "macos")]
@@ -276,6 +338,18 @@ fn read_hide_dock_icon<R: Runtime>(app: &AppHandle<R>) -> bool {
 /// Called from the global `on_menu_event` handler in `lib.rs` when an
 /// id starts with `tray-`. Returns `true` if the id was handled here.
 pub fn handle_menu_event<R: Runtime + 'static>(app: &AppHandle<R>, id: &str) -> bool {
+    if id.starts_with("tray-host-") {
+        let host_id = &id["tray-host-".len()..];
+        let state = app.state::<AppState>();
+        if let Ok(manifest) = Manifest::load(&state.paths) {
+            if let Some(node) = crate::storage::manifest::find_node(&manifest.root, host_id) {
+                let current_on = node.get("on").and_then(|v| v.as_bool()).unwrap_or(false);
+                let _ = app.emit("toggle_item", json!({ "_args": [host_id, !current_on] }));
+            }
+        }
+        return true;
+    }
+
     match id {
         MENU_ID_SHOW_MAIN => {
             show_main_window(app);

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -350,7 +350,15 @@ pub fn handle_menu_event<R: Runtime + 'static>(app: &AppHandle<R>, id: &str) -> 
                 } else if let Some(tray_win) = app.get_webview_window(TRAY_WINDOW_LABEL) {
                     let _ = tray_win.emit("tray_toggle_item", json!({ "_args": [host_id, !current_on] }));
                 } else {
-                    crate::lifecycle::show_main_window(app);
+                    if let Ok(tray_win) = create_tray_window(app) {
+                        let host_id = host_id.to_string();
+                        tauri::async_runtime::spawn(async move {
+                            tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+                            let _ = tray_win.emit("tray_toggle_item", json!({ "_args": [&host_id, !current_on] }));
+                        });
+                    } else {
+                        crate::lifecycle::show_main_window(app);
+                    }
                 }
             }
         }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -347,7 +347,7 @@ pub fn handle_menu_event<R: Runtime + 'static>(app: &AppHandle<R>, id: &str) -> 
                 let main_win = app.get_webview_window(crate::lifecycle::MAIN_WINDOW_LABEL);
                 if main_win.is_some() {
                     let _ = app.emit("toggle_item", json!({ "_args": [host_id, !current_on] }));
-                } else if let Some(tray_win) = app.get_webview_window("tray_window") {
+                } else if let Some(tray_win) = app.get_webview_window(TRAY_WINDOW_LABEL) {
                     let _ = tray_win.emit("tray_toggle_item", json!({ "_args": [host_id, !current_on] }));
                 } else {
                     crate::lifecycle::show_main_window(app);

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -344,22 +344,13 @@ pub fn handle_menu_event<R: Runtime + 'static>(app: &AppHandle<R>, id: &str) -> 
         if let Ok(manifest) = Manifest::load(&state.paths) {
             if let Some(node) = crate::storage::manifest::find_node(&manifest.root, host_id) {
                 let current_on = node.get("on").and_then(|v| v.as_bool()).unwrap_or(false);
-                let main_win = app.get_webview_window(crate::lifecycle::MAIN_WINDOW_LABEL);
-                if main_win.is_some() {
-                    let _ = app.emit("toggle_item", json!({ "_args": [host_id, !current_on] }));
-                } else if let Some(tray_win) = app.get_webview_window(TRAY_WINDOW_LABEL) {
-                    let _ = tray_win.emit("tray_toggle_item", json!({ "_args": [host_id, !current_on] }));
-                } else {
-                    if let Ok(tray_win) = create_tray_window(app) {
-                        let host_id = host_id.to_string();
-                        tauri::async_runtime::spawn(async move {
-                            tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
-                            let _ = tray_win.emit("tray_toggle_item", json!({ "_args": [&host_id, !current_on] }));
-                        });
-                    } else {
-                        crate::lifecycle::show_main_window(app);
-                    }
-                }
+                // Toggle + apply entirely in the backend so it works no
+                // matter which windows are alive — including lightweight
+                // mode, where the main window has been destroyed. Doing
+                // the apply here (rather than broadcasting to a webview)
+                // removes the old dependency on a live renderer and the
+                // fragile "create a window and wait" fallback.
+                crate::commands::toggle_host_from_tray(app, host_id, !current_on);
             }
         }
         return true;

--- a/src/common/events.ts
+++ b/src/common/events.ts
@@ -31,6 +31,7 @@ export default {
   toggle_comment: 'toggle_comment',
   toggle_developer_tools: 'toggle_developer_tools',
   toggle_item: 'toggle_item',
+  tray_toggle_item: 'tray_toggle_item',
   toggle_left_panel: 'toggle_left_panel',
   toggle_right_panel: 'toggle_right_panel',
   tray_list_updated: 'tray:list_updated',

--- a/src/renderer/components/List/ListItem.tsx
+++ b/src/renderer/components/List/ListItem.tsx
@@ -79,7 +79,17 @@ const ListItem = (props: Props) => {
     on = typeof on === 'boolean' ? on : !isOn
     setIsOn(on)
 
-    agent.broadcast(events.toggle_item, data.id, on)
+    if (isTray) {
+      agent.call('is_main_window_alive').then((isMainAlive: boolean) => {
+        if (isMainAlive) {
+          agent.broadcast(events.toggle_item, data.id, on)
+        } else {
+          agent.broadcast(events.tray_toggle_item, data.id, on)
+        }
+      }).catch(console.error)
+    } else {
+      agent.broadcast(events.toggle_item, data.id, on)
+    }
   }
 
   if (!data) return null

--- a/src/renderer/components/List/index.tsx
+++ b/src/renderer/components/List/index.tsx
@@ -173,6 +173,15 @@ const List = (props: Props) => {
     [hostsData, configs, isTray],
   )
   useOnBroadcast(
+    events.tray_toggle_item,
+    (id: string, on: boolean) => {
+      if (isTray) {
+        onToggleItem(id, on)
+      }
+    },
+    [hostsData, configs, isTray],
+  )
+  useOnBroadcast(
     events.tray_list_updated,
     () => {
       if (!isTray) return


### PR DESCRIPTION
## Summary

Adds hosts entries to the system tray (menu bar) menu so users can switch hosts profiles directly from the tray, and makes that toggle work reliably **even in lightweight mode** where the main window is destroyed.

## What's included

- **Tray menu lists hosts profiles** — top-level items become checkable menu items; folders become submenus (nested folders supported). Checkmarks reflect each profile's on-state.
- **Clicking a profile toggles it and applies to the system hosts file** — the toggle + apply now runs **entirely in the Rust backend**, with no dependency on any webview being alive.
- **Tray menu stays in sync** — the menu is rebuilt after list mutations (`set_list`, trashcan move/restore) and after every apply.

## Why the backend approach

The original implementation relied on the renderer (main window) to perform the actual toggle + apply. In lightweight mode the main window is destroyed, so an earlier iteration created a hidden tray window and waited a fixed 2000 ms before emitting the toggle event — racy and fragile.

This PR ports the renderer's `setOnStateOfItem` logic (`src/common/hostsFn.ts`) to Rust (`manifest::set_on_state_of_item`) and performs the toggle + system-hosts apply on a background task in the backend. The renderer-driven command path and the tray path now share the same `apply_aggregated_content` pipeline, guaranteeing identical results whether you switch from the UI or the tray.

## Notable details

- Choice-mode / folder-mode single-selection exclusion and the optional folder cascade are all reproduced in Rust and covered by 8 unit tests (`set_on_tests`), which pass.
- When no write mode is configured, the tray path surfaces the main window and prompts (mirroring the renderer's gate) instead of silently applying.

## Testing

- `cargo test --lib set_on_tests` → 8 passed.
- `cargo check --tests` → clean.

 ## Related issue
  
Fixes #1020