### PR TITLE
fix(http-api): apply toggle in the backend when no renderer is alive

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -661,6 +661,31 @@ pub async fn apply_hosts_selection<R: Runtime>(
         }
     };
 
+    match apply_aggregated_content(&app, state.inner(), &content).await {
+        Ok(outcome) => Ok(json!({
+            "success": true,
+            "old_content": outcome.previous_content,
+            "new_content": outcome.new_content,
+        })),
+        Err(ApplyPipelineError::Apply(e)) => Ok(e.into_renderer_value()),
+    }
+}
+
+/// Everything an apply entails beyond the raw write: the privileged
+/// write itself, the apply-history journal, the `system_hosts_updated`
+/// broadcast, the tray title refresh and `cmd_after_hosts_apply`.
+///
+/// Extracted so callers that bypass the renderer — currently the HTTP
+/// API when no window is alive to run `onToggleItem` — get the same
+/// pipeline as a UI-driven apply instead of a bare write that silently
+/// skips history and the post-apply command. Note the tray refresh here
+/// reads manifest.json from disk, so a caller that persists the tree
+/// afterwards must refresh again once the new tree has landed.
+pub(crate) async fn apply_aggregated_content<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &AppState,
+    content: &str,
+) -> Result<hosts_apply::write::ApplyOutcome, ApplyPipelineError> {
     let (write_mode, history_limit, cmd_after_apply) = {
         let cfg = state.config.lock().expect("config mutex poisoned");
         (
@@ -674,14 +699,31 @@ pub async fn apply_hosts_selection<R: Runtime>(
     // user at the OS auth prompt) and *must not* hold the store_lock —
     // see implementation-notes A5. We do all the work outside the lock
     // and only retake it for the history journal write below.
-    let outcome = match hosts_apply::apply_to_system_hosts(&content, &write_mode) {
-        Ok(o) => o,
-        Err(HostsApplyError::Cancelled) => {
-            return Ok(HostsApplyError::Cancelled.into_renderer_value());
+    // Off the async workers: the privileged write blocks on an OS auth
+    // prompt for as long as the user takes, and on macOS it also holds a
+    // std mutex while doing so. Awaiting that inline would pin a worker
+    // of the runtime shared by the HTTP server and every async command.
+    let write_result = {
+        let content = content.to_string();
+        let write_mode = write_mode.clone();
+        tauri::async_runtime::spawn_blocking(move || {
+            hosts_apply::apply_to_system_hosts(&content, &write_mode)
+        })
+        .await
+    };
+    let outcome = match write_result {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
+            if !matches!(e, HostsApplyError::Cancelled) {
+                log::warn!("apply failed: {e}");
+            }
+            return Err(ApplyPipelineError::Apply(e));
         }
         Err(e) => {
-            log::warn!("apply failed: {e}");
-            return Ok(e.into_renderer_value());
+            log::warn!("apply task failed to run: {e}");
+            return Err(ApplyPipelineError::Apply(HostsApplyError::Io {
+                message: format!("apply task failed to run: {e}"),
+            }));
         }
     };
 
@@ -729,7 +771,7 @@ pub async fn apply_hosts_selection<R: Runtime>(
     // Push the freshest tray title to the menubar without waiting on
     // the renderer to call `update_tray_title` — the user expects to
     // see the title flip immediately after an apply.
-    if let Err(e) = tray::refresh_title(&app, state.inner()) {
+    if let Err(e) = tray::refresh_title(app, state) {
         log::warn!("failed to refresh tray title: {e}");
     }
 
@@ -754,11 +796,14 @@ pub async fn apply_hosts_selection<R: Runtime>(
         }
     }
 
-    Ok(json!({
-        "success": true,
-        "old_content": outcome.previous_content,
-        "new_content": outcome.new_content,
-    }))
+    Ok(outcome)
+}
+
+/// Failure modes of [`apply_aggregated_content`]. Currently only wraps
+/// the write itself; kept as an enum so later stages can surface their
+/// own errors without changing every call site.
+pub(crate) enum ApplyPipelineError {
+    Apply(HostsApplyError),
 }
 
 // ---- privileged helper (macOS SMAppService) --------------------------------

--- a/src-tauri/src/http_api.rs
+++ b/src-tauri/src/http_api.rs
@@ -8,7 +8,13 @@
 //! | GET    | `/`            | `Hello SwitchHosts!` |
 //! | GET    | `/remote-test` | `# remote-test\n# <timestamp>` |
 //! | GET    | `/api/list`    | `{success, data: flat_list}` JSON |
-//! | GET    | `/api/toggle?id=<id>` | `ok` / `bad id.` / `not found.` |
+//! | GET    | `/api/toggle?id=<id>` | `ok` / `bad id.` / `not found.` / see below |
+//!
+//! When the toggle is applied in the backend (no renderer, see below)
+//! it can also answer `cancelled.` (user dismissed the OS auth
+//! prompt), `write mode not set.`, `applied but not persisted.` or
+//! `apply failed.`. All replies are 200 with a terse body, matching
+//! the existing ones.
 //!
 //! Lifecycle:
 //!
@@ -26,16 +32,22 @@
 //!   stays in sync with the renderer's preferences pane without a
 //!   restart.
 //!
-//! Toggle behaviour: matches the Electron implementation byte for
-//! byte — the toggle handler emits the `toggle_item` event with the
-//! flipped `on` value, and the main window's `onToggleItem` listener
-//! handles the actual apply pipeline (including `choice_mode` /
-//! folder semantics from `setOnStateOfItem`). The v5 storage plan
-//! noted that doing the apply directly inside the HTTP handler would
-//! work even when no renderer is alive, but in our build the main
-//! window is created at startup and only ever hidden, so the
-//! broadcast always reaches a live listener. The simpler port keeps
-//! `choice_mode` semantics centralised in one place.
+//! Toggle behaviour: with a main window alive this matches the
+//! Electron implementation byte for byte — the handler emits
+//! `toggle_item` with the flipped `on` value and the window's
+//! `onToggleItem` runs the apply pipeline, keeping `choice_mode` /
+//! folder semantics from `setOnStateOfItem` in one place.
+//!
+//! A Tauri event with no listener is dropped, though, and there are
+//! two supported configurations with no main window: `hide_at_launch`
+//! skips window creation at setup, and `lightweight_mode` destroys the
+//! window when the user closes it. In both, the broadcast reaches
+//! nobody while the endpoint still answers `ok`. The v5 storage plan
+//! anticipated this — it noted that applying directly inside the HTTP
+//! handler works even when no renderer is alive — so that is what the
+//! no-window path does, reusing the renderer's selection rules
+//! (`manifest::set_on_state_of_item`) and the same apply pipeline
+//! (`commands::apply_aggregated_content`) rather than a bare write.
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Mutex;
@@ -48,7 +60,11 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use tauri::{AppHandle, Emitter, Manager, Wry};
 
-use crate::storage::{manifest::Manifest, AppState};
+use crate::commands;
+use crate::hosts_apply::{self, HostsApplyError};
+use crate::lifecycle::MAIN_WINDOW_LABEL;
+use crate::storage::{manifest, manifest::Manifest, AppState};
+use crate::tray;
 
 // We pin the HTTP API to the default `Wry` runtime instead of staying
 // generic over `R: Runtime`. axum's `Handler` trait requires the
@@ -203,8 +219,164 @@ async fn api_toggle(
     // including choice_mode / folder cascading semantics from
     // `setOnStateOfItem`. The envelope is the same `_args` shape every
     // other Tauri broadcast in this codebase uses.
-    let _ = state.app.emit("toggle_item", json!({ "_args": [id, !on] }));
-    "ok"
+    if state.app.get_webview_window(MAIN_WINDOW_LABEL).is_some() {
+        let _ = state.app.emit("toggle_item", json!({ "_args": [id, !on] }));
+        return "ok";
+    }
+
+    // No main window: a Tauri event with no listener is dropped, so the
+    // broadcast above would silently do nothing. Apply in the handler
+    // instead, reusing the same selection rules the renderer applies.
+    match apply_toggle_in_backend(&state.app, manifest, &id, !on).await {
+        Ok(()) => "ok",
+        Err(e) => {
+            // A cancelled prompt is a deliberate user action, not a fault;
+            // the renderer path stays quiet about it too.
+            if matches!(e, ToggleError::Apply(HostsApplyError::Cancelled)) {
+                log::info!("toggle cancelled by the user: {id}");
+            } else {
+                log::warn!("toggle failed for {id}: {e}");
+            }
+            e.as_body()
+        }
+    }
+}
+
+/// Serialises backend applies. Without it two concurrent HTTP toggles
+/// would each stack an OS auth prompt and race to write the same files.
+static BACKEND_APPLY_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Backend-side equivalent of the renderer's `onToggleItem`: flip the
+/// node, apply through the same pipeline a UI-driven apply uses, then
+/// persist the tree. Used only when no renderer is alive to receive
+/// `toggle_item`.
+async fn apply_toggle_in_backend(
+    app: &AppHandle<Wry>,
+    manifest: Manifest,
+    id: &str,
+    on: bool,
+) -> Result<(), ToggleError> {
+    // One backend apply at a time. The privileged write can sit on an OS
+    // auth prompt indefinitely, and `cmd_after_hosts_apply` adds up to
+    // 30s on top; letting requests overlap would stack prompts and make
+    // the store races below unavoidable.
+    let _apply_guard = BACKEND_APPLY_LOCK.lock().await;
+
+    let app_state = app.state::<AppState>();
+    app_state
+        .require_data_dir_usable()
+        .map_err(|e| ToggleError::Storage(e.to_string()))?;
+
+    let (choice_mode, multi_chose_folder_switch_all, remove_duplicate, write_mode) = {
+        let cfg = app_state.config.lock().expect("config mutex poisoned");
+        (
+            cfg.choice_mode as u64,
+            cfg.multi_chose_folder_switch_all,
+            cfg.remove_duplicate_records,
+            cfg.write_mode.clone(),
+        )
+    };
+
+    // The renderer refuses to apply before a write mode is chosen and
+    // opens the picker instead (`onToggleItem` in List/index.tsx). We
+    // have no UI to fall back on, so refuse rather than silently taking
+    // `apply_to_system_hosts`'s overwrite default — that would wipe
+    // hand-written entries for anyone still carrying the empty value
+    // from an Electron-era config.
+    if write_mode.is_empty() {
+        return Err(ToggleError::WriteModeUnset);
+    }
+
+    let mut proposed = manifest;
+    manifest::set_on_state_of_item(
+        &mut proposed.root,
+        id,
+        on,
+        choice_mode,
+        multi_chose_folder_switch_all,
+    );
+
+    let content =
+        hosts_apply::aggregate_selected_content(&proposed.root, &app_state.paths, remove_duplicate)
+            .map_err(|e| ToggleError::Storage(e.to_string()))?;
+
+    commands::apply_aggregated_content(app, app_state.inner(), &content)
+        .await
+        .map_err(|commands::ApplyPipelineError::Apply(e)| ToggleError::Apply(e))?;
+
+    // Re-read under the store lock and re-apply the flip, rather than
+    // saving the tree we loaded before the write. The apply above can
+    // block on an auth prompt for minutes, and the refresh scanner or a
+    // tray window may have legitimately rewritten manifest.json in the
+    // meantime — saving our stale snapshot would clobber that. Same
+    // reasoning as the remote-refresh path in `refresh.rs`.
+    {
+        let _guard = app_state.store_lock.lock().expect("store lock poisoned");
+        let mut fresh =
+            Manifest::load(&app_state.paths).map_err(|e| ToggleError::Persist(e.to_string()))?;
+        manifest::set_on_state_of_item(
+            &mut fresh.root,
+            id,
+            on,
+            choice_mode,
+            multi_chose_folder_switch_all,
+        );
+        fresh
+            .save(&app_state.paths)
+            .map_err(|e| ToggleError::Persist(e.to_string()))?;
+    }
+
+    // `tray::refresh_title` reads manifest.json from disk, so the call
+    // inside the apply pipeline saw the pre-toggle tree. Refresh again
+    // now that the new one has landed, otherwise the menubar title
+    // trails one toggle behind — and with no window open it is the only
+    // place the user can see which profile is active.
+    if let Err(e) = tray::refresh_title(app, app_state.inner()) {
+        log::warn!("failed to refresh tray title after backend toggle: {e}");
+    }
+    // Mirrors the renderer's post-apply broadcast: a tray mini window is
+    // built lazily and then reused, so without this its list keeps
+    // showing the pre-toggle state.
+    let _ = app.emit("tray_list_updated", json!({ "_args": [] }));
+
+    Ok(())
+}
+
+/// Why a backend toggle failed. Kept distinct so the endpoint can say
+/// which, instead of collapsing a user-cancelled prompt, a policy denial
+/// and a full disk into one opaque string.
+enum ToggleError {
+    WriteModeUnset,
+    Apply(HostsApplyError),
+    /// The write succeeded but the tree could not be persisted — the
+    /// system file and manifest.json now disagree.
+    Persist(String),
+    Storage(String),
+}
+
+impl ToggleError {
+    /// Response body. Terse and stable, like the existing `bad id.` /
+    /// `not found.` replies.
+    fn as_body(&self) -> &'static str {
+        match self {
+            ToggleError::WriteModeUnset => "write mode not set.",
+            ToggleError::Apply(HostsApplyError::Cancelled) => "cancelled.",
+            ToggleError::Apply(_) => "apply failed.",
+            ToggleError::Persist(_) => "applied but not persisted.",
+            ToggleError::Storage(_) => "apply failed.",
+        }
+    }
+}
+
+impl std::fmt::Display for ToggleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ToggleError::WriteModeUnset => write!(f, "write mode is not set"),
+            ToggleError::Apply(e) => write!(f, "{e}"),
+            ToggleError::Persist(e) => write!(f, "applied but failed to persist the tree: {e}"),
+            ToggleError::Storage(e) => write!(f, "{e}"),
+        }
+    }
 }
 
 // ---- tree helpers ----------------------------------------------------------

--- a/src-tauri/src/storage/manifest.rs
+++ b/src-tauri/src/storage/manifest.rs
@@ -224,3 +224,419 @@ pub fn collect_content_ids(nodes: &[Value], out: &mut Vec<String>) {
         }
     }
 }
+
+// ---- selection state -------------------------------------------------------
+//
+// Port of `setOnStateOfItem` in `src/common/hostsFn.ts`. The renderer owns
+// this logic for UI-driven toggles; the HTTP API needs the same semantics
+// when no window — and therefore no renderer — is loaded, which is the
+// normal state under `hide_at_launch`.
+//
+// Nodes are addressed by index path rather than by `&mut` handles so a
+// child and its ancestors can be touched in one pass without fighting the
+// borrow checker.
+
+/// Index path from the root forest down to `id`, or `None` if absent.
+fn path_of(nodes: &[Value], id: &str) -> Option<Vec<usize>> {
+    for (i, node) in nodes.iter().enumerate() {
+        if node_id(node) == Some(id) {
+            return Some(vec![i]);
+        }
+        if let Some(children) = node_children(node) {
+            if let Some(mut sub) = path_of(children, id) {
+                let mut path = vec![i];
+                path.append(&mut sub);
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+fn node_at<'a>(nodes: &'a [Value], path: &[usize]) -> Option<&'a Value> {
+    let (first, rest) = path.split_first()?;
+    let node = nodes.get(*first)?;
+    if rest.is_empty() {
+        return Some(node);
+    }
+    node_at(node_children(node)?, rest)
+}
+
+fn node_at_mut<'a>(nodes: &'a mut [Value], path: &[usize]) -> Option<&'a mut Value> {
+    let (first, rest) = path.split_first()?;
+    let node = nodes.get_mut(*first)?;
+    if rest.is_empty() {
+        return Some(node);
+    }
+    node_at_mut(node_children_mut(node)?, rest)
+}
+
+fn set_node_on(node: &mut Value, on: bool) {
+    if let Some(obj) = node.as_object_mut() {
+        obj.insert("on".to_string(), Value::Bool(on));
+    }
+}
+
+/// A folder's own choice mode. `0`/absent means "inherit the global
+/// `choice_mode`", matching the renderer's `parent.folder_mode || default`.
+fn folder_mode(node: &Value) -> Option<u64> {
+    node.get("folder_mode")
+        .and_then(Value::as_u64)
+        .filter(|mode| *mode != 0)
+}
+
+fn is_folder(node: &Value) -> bool {
+    node.get("type").and_then(Value::as_str) == Some("folder")
+}
+
+/// Cascade `on` to every descendant of a folder. Single-choice folders
+/// are left alone — their children are mutually exclusive by definition.
+fn switch_folder_child(node: &mut Value, on: bool) {
+    if !is_folder(node) || folder_mode(node) == Some(1) {
+        return;
+    }
+    let Some(children) = node_children_mut(node) else {
+        return;
+    };
+    for child in children.iter_mut() {
+        set_node_on(child, on);
+        switch_folder_child(child, on);
+    }
+}
+
+/// Walk up from `path`, keeping each ancestor folder's `on` in sync:
+/// turning a child off turns the parent off; turning one on marks the
+/// parent on only once every sibling is on.
+fn switch_item_parent_is_on(root: &mut Vec<Value>, path: &[usize], on: bool) {
+    if path.len() < 2 {
+        return; // top-level node: no parent to reconcile
+    }
+    let parent_path = &path[..path.len() - 1];
+    {
+        let Some(parent) = node_at_mut(root, parent_path) else {
+            return;
+        };
+        if folder_mode(parent) == Some(1) {
+            return;
+        }
+        if !on {
+            set_node_on(parent, false);
+        } else {
+            let all_on = node_children(parent)
+                .map(|children| {
+                    children
+                        .iter()
+                        .all(|c| c.get("on").and_then(Value::as_bool).unwrap_or(false))
+                })
+                .unwrap_or(false);
+            set_node_on(parent, all_on);
+        }
+    }
+    switch_item_parent_is_on(root, parent_path, on);
+}
+
+/// Set `id`'s on-state and apply the same folder/choice-mode rules the
+/// renderer applies, in place on the legacy-shaped root forest.
+///
+/// `default_choice_mode` is the global `choice_mode` config value (`1` =
+/// single choice). `multi_chose_folder_switch_all` mirrors the config flag
+/// of the same name: when set, toggling a folder cascades to its children
+/// and reconciles its ancestors.
+pub fn set_on_state_of_item(
+    root: &mut Vec<Value>,
+    id: &str,
+    on: bool,
+    default_choice_mode: u64,
+    multi_chose_folder_switch_all: bool,
+) {
+    let Some(path) = path_of(root, id) else {
+        return;
+    };
+    if let Some(node) = node_at_mut(root, &path) {
+        set_node_on(node, on);
+    }
+
+    let in_top_level = path.len() == 1;
+    if multi_chose_folder_switch_all {
+        if let Some(node) = node_at_mut(root, &path) {
+            switch_folder_child(node, on);
+        }
+        if !in_top_level {
+            switch_item_parent_is_on(root, &path, on);
+        }
+    }
+
+    // Turning something off never forces anything else on.
+    if !on {
+        return;
+    }
+
+    if in_top_level {
+        if default_choice_mode != 1 {
+            return;
+        }
+        let chosen = path[0];
+        for (i, node) in root.iter_mut().enumerate() {
+            if i == chosen {
+                continue;
+            }
+            set_node_on(node, false);
+            if multi_chose_folder_switch_all {
+                switch_folder_child(node, false);
+            }
+        }
+        return;
+    }
+
+    let parent_path = &path[..path.len() - 1];
+    let mode = node_at(root, parent_path)
+        .and_then(folder_mode)
+        .unwrap_or(default_choice_mode);
+    if mode != 1 {
+        return;
+    }
+    let chosen = *path.last().expect("path is non-empty");
+    let Some(parent) = node_at_mut(root, parent_path) else {
+        return;
+    };
+    let Some(children) = node_children_mut(parent) else {
+        return;
+    };
+    for (i, child) in children.iter_mut().enumerate() {
+        if i == chosen {
+            continue;
+        }
+        set_node_on(child, false);
+        if multi_chose_folder_switch_all {
+            switch_folder_child(child, false);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn leaf(id: &str, on: bool) -> Value {
+        json!({ "id": id, "title": id, "type": "local", "on": on })
+    }
+
+    fn folder(id: &str, on: bool, mode: u64, children: Vec<Value>) -> Value {
+        json!({
+            "id": id, "title": id, "type": "folder", "on": on,
+            "folder_mode": mode, "children": children,
+        })
+    }
+
+    /// A folder that carries no `folder_mode` of its own.
+    fn folder_no_mode(id: &str, on: bool, children: Vec<Value>) -> Value {
+        json!({
+            "id": id, "title": id, "type": "folder", "on": on, "children": children,
+        })
+    }
+
+    fn on_of(root: &[Value], id: &str) -> bool {
+        let path = path_of(root, id).expect("node must exist");
+        node_at(root, &path)
+            .and_then(|n| n.get("on"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn sets_the_target_node_and_leaves_siblings_alone_in_multi_choice() {
+        let mut root = vec![leaf("a", false), leaf("b", true)];
+        set_on_state_of_item(&mut root, "a", true, 2, false);
+        assert!(on_of(&root, "a"));
+        assert!(on_of(&root, "b"), "multi-choice must not turn siblings off");
+    }
+
+    #[test]
+    fn single_choice_turns_other_top_level_nodes_off() {
+        let mut root = vec![leaf("a", false), leaf("b", true), leaf("c", true)];
+        set_on_state_of_item(&mut root, "a", true, 1, false);
+        assert!(on_of(&root, "a"));
+        assert!(!on_of(&root, "b"));
+        assert!(!on_of(&root, "c"));
+    }
+
+    #[test]
+    fn turning_off_never_switches_anything_else_on() {
+        let mut root = vec![leaf("a", true), leaf("b", false)];
+        set_on_state_of_item(&mut root, "a", false, 1, false);
+        assert!(!on_of(&root, "a"));
+        assert!(!on_of(&root, "b"));
+    }
+
+    #[test]
+    fn folder_toggle_cascades_to_children_when_switch_all_is_set() {
+        let mut root = vec![folder(
+            "f",
+            false,
+            2,
+            vec![leaf("c1", false), leaf("c2", false)],
+        )];
+        set_on_state_of_item(&mut root, "f", true, 2, true);
+        assert!(on_of(&root, "f"));
+        assert!(on_of(&root, "c1"));
+        assert!(on_of(&root, "c2"));
+    }
+
+    #[test]
+    fn single_choice_folder_does_not_cascade_to_its_children() {
+        let mut root = vec![folder("f", false, 1, vec![leaf("c1", false)])];
+        set_on_state_of_item(&mut root, "f", true, 2, true);
+        assert!(on_of(&root, "f"));
+        assert!(
+            !on_of(&root, "c1"),
+            "children of a single-choice folder are mutually exclusive, so a \
+             folder toggle must not switch them all on"
+        );
+    }
+
+    #[test]
+    fn turning_one_child_off_turns_the_parent_off() {
+        let mut root = vec![folder(
+            "f",
+            true,
+            2,
+            vec![leaf("c1", true), leaf("c2", true)],
+        )];
+        set_on_state_of_item(&mut root, "c1", false, 2, true);
+        assert!(!on_of(&root, "c1"));
+        assert!(on_of(&root, "c2"), "the other child stays on");
+        assert!(!on_of(&root, "f"), "parent follows its children off");
+    }
+
+    #[test]
+    fn parent_turns_on_only_once_every_child_is_on() {
+        let mut root = vec![folder(
+            "f",
+            false,
+            2,
+            vec![leaf("c1", false), leaf("c2", false)],
+        )];
+        set_on_state_of_item(&mut root, "c1", true, 2, true);
+        assert!(
+            !on_of(&root, "f"),
+            "one of two children on: parent stays off"
+        );
+        set_on_state_of_item(&mut root, "c2", true, 2, true);
+        assert!(on_of(&root, "f"), "all children on: parent turns on");
+    }
+
+    #[test]
+    fn folder_mode_overrides_the_global_choice_mode_for_its_children() {
+        // Global mode is multi-choice, but this folder is single-choice.
+        let mut root = vec![folder(
+            "f",
+            true,
+            1,
+            vec![leaf("c1", true), leaf("c2", false)],
+        )];
+        set_on_state_of_item(&mut root, "c2", true, 2, false);
+        assert!(on_of(&root, "c2"));
+        assert!(
+            !on_of(&root, "c1"),
+            "single-choice folder unsets the sibling"
+        );
+    }
+
+    #[test]
+    fn nested_folders_reconcile_all_the_way_up() {
+        let mut root = vec![folder(
+            "outer",
+            true,
+            2,
+            vec![folder("inner", true, 2, vec![leaf("c1", true)])],
+        )];
+        set_on_state_of_item(&mut root, "c1", false, 2, true);
+        assert!(!on_of(&root, "inner"));
+        assert!(
+            !on_of(&root, "outer"),
+            "the reconcile walk must not stop at the first parent"
+        );
+    }
+
+    #[test]
+    fn unknown_id_is_a_no_op() {
+        let mut root = vec![leaf("a", true)];
+        set_on_state_of_item(&mut root, "nope", false, 1, true);
+        assert!(on_of(&root, "a"));
+    }
+
+    #[test]
+    fn folder_without_its_own_mode_inherits_the_global_choice_mode() {
+        let mut root = vec![folder_no_mode(
+            "f",
+            true,
+            vec![leaf("c1", true), leaf("c2", false)],
+        )];
+        set_on_state_of_item(&mut root, "c2", true, 1, false);
+        assert!(on_of(&root, "c2"));
+        assert!(
+            !on_of(&root, "c1"),
+            "a folder with no mode of its own must fall back to the global \
+             choice_mode, so single choice still applies to its children"
+        );
+    }
+
+    #[test]
+    fn folder_mode_zero_inherits_the_global_choice_mode() {
+        // `0` is the renderer's "unset" value — `parent.folder_mode ||
+        // defaultChoiceMode` treats it as falsy.
+        let mut root = vec![folder(
+            "f",
+            true,
+            0,
+            vec![leaf("c1", true), leaf("c2", false)],
+        )];
+        set_on_state_of_item(&mut root, "c2", true, 1, false);
+        assert!(on_of(&root, "c2"));
+        assert!(
+            !on_of(&root, "c1"),
+            "folder_mode 0 means inherit, not multi-choice"
+        );
+    }
+
+    #[test]
+    fn single_choice_takes_the_children_of_the_folders_it_switches_off() {
+        let mut root = vec![
+            folder("f", true, 2, vec![leaf("c1", true), leaf("c2", true)]),
+            leaf("a", false),
+        ];
+        set_on_state_of_item(&mut root, "a", true, 1, true);
+        assert!(on_of(&root, "a"));
+        assert!(!on_of(&root, "f"));
+        assert!(
+            !on_of(&root, "c1") && !on_of(&root, "c2"),
+            "switching a top-level folder off under single choice must cascade to its children"
+        );
+    }
+
+    #[test]
+    fn a_single_choice_folder_does_not_follow_its_children_off() {
+        // Its children are mutually exclusive, so the folder's own state is
+        // not derived from them — the parent reconcile walk skips it.
+        let mut root = vec![folder(
+            "f",
+            true,
+            1,
+            vec![leaf("c1", true), leaf("c2", false)],
+        )];
+        set_on_state_of_item(&mut root, "c1", false, 2, true);
+        assert!(!on_of(&root, "c1"));
+        assert!(on_of(&root, "f"));
+    }
+
+    #[test]
+    fn only_folders_cascade_even_if_another_node_type_carries_children() {
+        let mut root = vec![json!({
+            "id": "l", "title": "l", "type": "local", "on": false,
+            "children": [ leaf("c1", false) ],
+        })];
+        set_on_state_of_item(&mut root, "l", true, 2, true);
+        assert!(on_of(&root, "l"));
+        assert!(!on_of(&root, "c1"));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1038 — with **Hide at launch** on, `GET /api/toggle` answers `ok` but does nothing.

`api_toggle` does not change state itself: it broadcasts `toggle_item` and relies on the main window's `onToggleItem` to run the apply pipeline. A Tauri event with no listener is dropped, and there are two supported configurations with no main window — `hide_at_launch` skips window creation at setup, and `lightweight_mode` destroys the window on close. In both, the broadcast reaches nobody and the endpoint still reports success.

The module doc of `http_api.rs` already names both the assumption and the way out:

> the v5 storage plan noted that doing the apply directly inside the HTTP handler would work even when no renderer is alive, but **in our build the main window is created at startup and only ever hidden**, so the broadcast always reaches a live listener.

That premise does not hold under `hide_at_launch`. This PR takes the documented alternative, but only for the case the premise misses.

## What changed

- **`http_api.rs`** — `api_toggle` broadcasts as before **when a main window exists**, and falls back to applying in the handler when there is none. The common path is untouched, so `choice_mode` semantics stay centralised in the renderer for every UI-driven toggle.
- **`commands.rs`** — the apply pipeline (privileged write, apply history, `system_hosts_updated`, tray title refresh, `cmd_after_hosts_apply`) is extracted from `apply_hosts_selection` into `apply_aggregated_content`, so both entry points produce identical side effects. `apply_hosts_selection` keeps its behaviour and just calls it.
- **`storage/manifest.rs`** — `set_on_state_of_item`, a port of the renderer's `setOnStateOfItem` (`src/common/hostsFn.ts`): single-choice exclusion at top level and inside folders, `folder_mode` overriding the global `choice_mode`, the optional folder cascade, and the parent-reconcile walk.

The backend path goes through the same `apply_aggregated_content` pipeline a UI-driven apply uses — a bare write would silently skip history and the post-apply command. Beyond that it takes the same precautions the renderer relies on:

- **Refuses to apply when no write mode is set.** The renderer opens the mode picker instead of applying; with no UI to fall back on, the backend returns `write mode not set.` rather than taking `apply_to_system_hosts`'s overwrite default and wiping hand-written entries for anyone still carrying the empty Electron-era value.
- **Re-reads the tree under `store_lock` after the write, then re-applies the flip.** The privileged write can sit on an auth prompt for minutes, and the refresh scanner may legitimately rewrite `manifest.json` meanwhile — saving the pre-apply snapshot would clobber it. Same shape as the remote-refresh path in `refresh.rs`.
- **Serialises backend applies** so concurrent requests cannot stack OS auth prompts, and **runs the blocking write on `spawn_blocking`** so it never pins a worker of the runtime shared by the HTTP server and every async command.
- **Refreshes the tray title after the save** — `tray::refresh_title` reads `manifest.json` from disk, so the call inside the pipeline sees the pre-toggle tree; without a second call the menubar trails one toggle behind, and with no window open it is the only place the active profile is visible. Also emits `tray_list_updated` so a lazily-built tray mini window does not keep showing stale state.
- **Distinguishes failures**: `cancelled.`, `write mode not set.`, `applied but not persisted.`, `apply failed.` — instead of collapsing a dismissed prompt, a policy denial and a full disk into one opaque reply.

Nothing is created, shown, or hidden differently — `hide_at_launch` still skips window creation exactly as before, and the structural test asserting that still passes.

## Tests

- 15 new unit tests for `set_on_state_of_item`: multi/single choice, folder cascade, single-choice folders, parent reconcile, nested folders, unknown ids, `folder_mode` absent/0 inheriting the global `choice_mode`, single-choice cascading into the folders it switches off, and cascade skipping non-folder nodes.
- `cargo test` → **182 passed, 0 failed** (including the existing `window_config` canaries, which assert that `hide_at_launch` must not create a window — untouched by this PR).
- `npm run test:all` (typecheck + vitest 84 + cargo + playwright 44) passes.

Manually verified on macOS with `hide_at_launch = true`, `http_api_on = true`, no window ever opened:

| action | result |
|---|---|
| toggle a top-level profile | switches, `/etc/hosts` written |
| toggle a folder (`multi_chose_folder_switch_all`) | folder + all children on |
| toggle one child off | child off, **parent auto-off**, sibling untouched |
| `choice_mode = 1`, toggle another profile | previous selection cleared |
| apply history / `cmd_after_hosts_apply` | recorded and run, same as a UI apply |
| tray title with `show_title_on_tray` | reflects the profile just switched on |
| `write_mode = ""` | refused, `/etc/hosts` untouched |

## Notes

This also restores the bundled Alfred workflow, whose action is exactly `curl 'http://127.0.0.1:50761/api/toggle?id={query}'`.

---

### 中文说明

修复 #1038 —— 开启「启动时隐藏窗口」后，`/api/toggle` 返回 `ok` 却没有任何效果。

`api_toggle` 本身不修改状态，它只广播 `toggle_item`，依赖主窗口的 `onToggleItem` 完成切换与应用。没有监听者的 Tauri 事件会被丢弃，而「启动时隐藏」会完全跳过主窗口的创建，于是广播无人接收，接口却仍然报告成功。

`http_api.rs` 的模块注释中已经同时写出了这个前提和出路：在 handler 里直接应用「即使没有 renderer 存活也能工作」。本 PR 采用的正是这个方案，但**只用在前提不成立的那种情况**。

**改动内容**

- **`http_api.rs`** —— 主窗口存在时照旧广播（UI 触发的切换仍然走 renderer，`choice_mode` 语义保持集中在一处）；只有在没有主窗口时才在 handler 内直接应用。
- **`commands.rs`** —— 把应用流程（提权写入、应用历史、`system_hosts_updated` 广播、托盘标题刷新、`cmd_after_hosts_apply`）从 `apply_hosts_selection` 中抽取为 `apply_aggregated_content`，使两个入口产生完全一致的副作用；`apply_hosts_selection` 行为不变，只是改为调用它。
- **`storage/manifest.rs`** —— 新增 `set_on_state_of_item`，把 renderer 的 `setOnStateOfItem`（`src/common/hostsFn.ts`）移植到 Rust：顶层与文件夹内的单选互斥、`folder_mode` 覆盖全局 `choice_mode`、可选的文件夹级联，以及父节点状态的回溯同步。

后端路径走的是与 UI 触发完全相同的 `apply_aggregated_content` 流程（只做裸写入会静默跳过历史记录和应用后命令），并且额外做了渲染进程本来就依赖的几项保护：

- **未设置写入模式时拒绝应用**：渲染进程会弹出模式选择框；后端没有 UI 可退回，因此返回 `write mode not set.`，而不是套用 overwrite 默认值把用户手写的 hosts 条目清掉。
- **写入完成后在 `store_lock` 下重新读取并重新应用**：提权写入可能在认证框上停留数分钟，其间远程刷新可能合法地改写了 `manifest.json`，直接保存旧快照会覆盖它。做法与 `refresh.rs` 的远程刷新路径一致。
- **串行化后端应用**，避免并发请求叠加认证框；**用 `spawn_blocking` 执行阻塞写入**，避免占用 HTTP 服务与所有 async 命令共用的运行时线程。
- **保存之后再刷新一次托盘标题**：`tray::refresh_title` 从磁盘读取 manifest，流程内那次调用看到的还是切换前的树；不补这一次的话菜单栏会永远慢一步，而在没有窗口时那是用户唯一能看到当前方案的地方。同时发出 `tray_list_updated`，避免已创建的托盘小窗显示过期状态。
- **区分失败原因**：`cancelled.` / `write mode not set.` / `applied but not persisted.` / `apply failed.`。

窗口的创建、显示、隐藏行为没有任何改变 —— 「启动时隐藏」依然跳过窗口创建，对应的结构性测试也依然通过。

**测试**

新增 15 个 `set_on_state_of_item` 单元测试（多选/单选、文件夹级联、单选文件夹、父节点回溯、嵌套文件夹、未知 id，以及 `folder_mode` 缺省/为 0 时继承全局 `choice_mode` 等）。`cargo test` → **182 passed, 0 failed**；`npm run test:all`（typecheck + vitest 84 + cargo + playwright 44）全部通过。

在 macOS 上以 `hide_at_launch = true`、`http_api_on = true`、且从未打开过窗口的状态下手动验证：切换顶层方案、切换文件夹（子项全开）、关闭其中一个子项（父节点自动关闭、兄弟节点不受影响）、`choice_mode = 1` 时切换另一个方案（原选中项被清除），`/etc/hosts` 均正确写入。

**附注**

这同时也修复了自带的 Alfred workflow —— 它的动作正是 `curl 'http://127.0.0.1:50761/api/toggle?id={query}'`。
